### PR TITLE
fix: make vertex_forager.logging a proper package; add import test

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/logging/__init__.py
+++ b/packages/vertex-forager/src/vertex_forager/logging/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+__all__ = [
+    "constants",
+]

--- a/packages/vertex-forager/tests/unit/test_logging_package_import.py
+++ b/packages/vertex-forager/tests/unit/test_logging_package_import.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import importlib
+
+
+def test_logging_constants_import() -> None:
+    mod = importlib.import_module("vertex_forager.logging.constants")
+    assert hasattr(mod, "ROUTER_LOG_PREFIX")
+    assert hasattr(mod, "CLIENT_LOG_PREFIX")


### PR DESCRIPTION
## 📝 Description

- Converts vertex_forager.logging into a proper Python package and eliminates ambiguity with stdlib logging .
- Ensures stable absolute imports for structured logging constants and prefix rules across the codebase.

## 🎯 Key Changes
- Add package initializer:
  - logging/ init .py
- Add lightweight import test:
  - test_logging_package_import.py
- Audit existing imports:
  - Confirmed usage of vertex_forager.logging.constants across routers/clients; no additional code changes required.

## ⚙️ Configuration
- No configuration changes required.
- Optional future alias (e.g., observability or log_constants ) can be introduced if a rename is needed; current module name retained to minimize disruption.

## ✅ Verification
- Lint: Ruff — Passing
- Type Check: mypy — Passing
- Tests:
  - New unit test passes (imports vertex_forager.logging.constants )
  - Full test suite green

## 📋 Acceptance Criteria Alignment
- Stable imports via vertex_forager.logging.constants without shadowing stdlib logging .
- Centralized, explicit module path for logging-related constants.
- pytest/ruff/mypy pass; no import warnings or collisions detected.

## 🔗 Linked Issues
- Closes #31
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **작업**
  * 로깅 패키지 초기화 추가

* **테스트**
  * 로깅 패키지 임포트 검증을 위한 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->