### PR TITLE
chore: Dependabot auto‑merge — author check, full checkout, path guard

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Disable auto-merge when dependencies label removed
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+        if: ${{ env.WORKFLOW_ONLY == 'false' || !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
         run: |
           PR_ID="$(gh pr view ${{ github.event.pull_request.number }} --json id --jq .id)"
           gh api graphql -f query='mutation($prId:ID!) { disablePullRequestAutoMerge(input:{pullRequestId:$prId}) { clientMutationId } }' -F prId="$PR_ID"


### PR DESCRIPTION
## 📝 Description

- Harden Dependabot auto‑merge so it only activates on genuine Dependabot PRs and only for workflow‑only changes. Preserves native GitHub auto‑merge while keeping human/code PRs out of the auto‑path.

## 🎯 Key Changes

- Author assertion: github.event.pull_request.user.login == 'dependabot[bot]'
- Label/base gates: requires dependencies label and base == main
- Full checkout: actions/checkout with fetch-depth: 0 for reliable BASE/HEAD diff
- Path guard: enable auto‑merge only when diff is strictly .github/workflows/**
- Permissions/token: contents/pull-requests write; use GITHUB_TOKEN
- Auto‑merge step: gh pr merge --squash --auto (waits for required checks)

## ⚙️ Configuration

- No changes to Rulesets or required checks; workflow only toggles native auto‑merge under safe conditions.
- Triggers: opened, synchronize, labeled, ready_for_review

## ✅ Verification

- Local logic review; prior Dependabot PR behavior validated under similar conditions
- Will exercise on next Dependabot PR; human PRs show job “Skipped” by design

## 📋 Acceptance Criteria Alignment

- Auto‑merge applied only to Dependabot PRs on main with dependencies label
- Required checks continue gating merges; human PRs remain manual
- Workflow‑only scope prevents unintended merges on code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* 의존성 자동 병합 워크플로우를 개선했습니다.
  * 워크플로우 이름을 일부 수정했습니다.
  * 자동 병합을 트리거하는 이벤트를 확장해 더 많은 PR 상황에서 작동합니다.
  * 권한 및 실행 조건을 워크플로우 내에서 정리하고 재구성했습니다.
  * 워크플로우 전용 변경만 허용하는 판단을 추가했습니다.
  * 특정 라벨에 따라 자동 병합을 자동 활성화/비활성화하도록 처리와 토큰 사용을 조정했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->