### PR TITLE
chore: tidy Trivy scanners and suppress version checks — keep fast PR gate, SARIF on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,13 @@ jobs:
         with:
           scan-type: fs
           trivyignores: .trivyignore
-          scanners: secret,config
+          scanners: secret,misconfig
           severity: HIGH,CRITICAL
           format: sarif
           output: trivy-results.sarif
           skip-dirs: ".hypothesis,.ruff_cache,data,output,packages/vertex-forager/legacy_code,.venv,.tox,.cache,build,dist,node_modules"
+        env:
+          TRIVY_SKIP_VERSION_CHECK: "true"
       - name: Check Trivy SARIF presence
         run: |
           if [ -f trivy-results.sarif ]; then
@@ -75,11 +77,13 @@ jobs:
         with:
           scan-type: fs
           trivyignores: .trivyignore
-          scanners: secret,config
+          scanners: secret,misconfig
           severity: HIGH,CRITICAL
           format: table
           exit-code: 1
           skip-dirs: ".hypothesis,.ruff_cache,data,output,packages/vertex-forager/legacy_code,.venv,.tox,.cache,build,dist,node_modules"
+        env:
+          TRIVY_SKIP_VERSION_CHECK: "true"
       - name: Remediation Hints (On Failure)
         if: ${{ failure() }}
         run: |


### PR DESCRIPTION
## 📝 Description

- Update Trivy flags to current recommendation and reduce CI log noise while preserving the fast PR gate + SARIF aggregation on main/schedule.
- Remove deprecated “config” scanner usage and suppress version check messages, keeping the existing security workflow unchanged.

## 🎯 Goals

- Eliminate deprecation warnings by standardizing scanners to secret,misconfig.
- Improve CI readability by suppressing version check notices.
- Maintain fast PR decision flow and Security tab aggregation on main.

## ✅ Scope of Work

- ci.yml
  - Use secret,misconfig for both Trivy steps:
    - SARIF step: ci.yml:L50-L61
    - Table gate: ci.yml:L74-L83
  - Suppress version checks for both steps via environment:
    - TRIVY_SKIP_VERSION_CHECK: "true" on SARIF step ci.yml:L61
    - TRIVY_SKIP_VERSION_CHECK: "true" on table gate ci.yml:L83
- CodeQL
  - No changes in this PR; prior configuration (PR upload suppressed, timeout, names, permissions) remains.

## 📋 Acceptance Criteria

- PR runs
  - No “‘--scanners config’ is deprecated” warnings.
  - Trivy table gate still fails immediately on HIGH/CRITICAL.
  - Required checks remain: Code Quality, mypy, CodeQL analyze; “Code scanning results / CodeQL” is Non‑required.
- Main push
  - Trivy SARIF upload executes and succeeds; Security tab aggregates updated results.
- CI readability
  - Version update notices from Trivy no longer printed in CI logs.

## 🔍 Verification

- Actions → Vertex CI (PR)
  - Confirm scanners=secret,misconfig appear in both Trivy steps and no deprecation warning lines.
  - Confirm table gate exits 1 when HIGH/CRITICAL findings exist.
- Actions → Vertex CI (main)
  - Confirm “Upload Trivy SARIF to Security tab” runs and succeeds.
- Security
  - Security → Code scanning alerts show up-to-date Trivy results for main; CodeQL continues to aggregate from main/schedule.

## ⚠️ Risks & Rollback

- Low risk; functional behavior unchanged.
- Rollback:
  - Revert scanners to prior values if needed.
  - Remove TRIVY_SKIP_VERSION_CHECK env to restore version notices.

## 🏷️ Labels

- ci, trivy, performance, code-scanning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI/CD 파이프라인 구성 업데이트: 보안 스캔 설정 개선 및 버전 확인 프로세스 최적화

**사용자 대면 변경 사항 없음** - 이 업데이트는 내부 개발 인프라 유지보수입니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->