### PR TITLE
docs: clarify unreachable FetchError due to tenacity reraise=true

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -951,4 +951,7 @@ class VertexForager:
                 self._observe("http_duration_s", dur)
                 self._log_structured(provider=job.provider, dataset=job.dataset, symbol=job.symbol, stage="http_end", attempt=att_no, duration_s=dur)
                 return resp
+        # Unreachable at runtime with tenacity.AsyncRetrying(reraise=True):
+        # the last exception is re-raised inside the loop when attempts are exhausted.
+        # Kept for static analysis clarity and as a defensive fallback.
         raise FetchError("Fetch failed after all retry attempts")


### PR DESCRIPTION
## 📝 Description

- Clarifies that the terminal FetchError in _fetch_with_retry is unreachable at runtime because tenacity’s AsyncRetrying uses reraise=True and re‑raises the last exception inside the loop when attempts are exhausted. The explicit raise is kept for static analysis and as a defensive fallback.

## 🎯 Goal

- Prevent confusion about execution paths while keeping intent clear for type checkers and maintainers.

## ✅ Acceptance Criteria

- A concise comment above the final raise in _fetch_with_retry explains reraise=True semantics and why the path is unreachable at runtime.
- No changes to control flow or public API.
- Lints and type checks pass.

## 🧪 Verification

- Ruff: pass
- mypy: pass
- Pytest: green (no test updates needed)
- File: packages/vertex-forager/src/vertex_forager/core/pipeline.py

## 📎 Linked Issue

- Closes #56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **품질 개선**
  * 재시도 메커니즘의 오류 처리 안정성을 강화하여 시스템 신뢰성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->