### PR TITLE
chore: PR body guard; type labels from title

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -79,9 +79,16 @@ jobs:
               'perf:': 'type:perf',
               'test:': 'type:test'
             };
+            // Support conventional commits with optional scope, e.g., "feat(core): ..."
+            const m = title.match(/^(feat|fix|chore|docs|refactor|perf|test)(\([^)]+\))?:\s/);
             let chosen = null;
-            for (const prefix of Object.keys(map)) {
-              if (title.startsWith(prefix)) { chosen = map[prefix]; break; }
+            if (m && m[1]) {
+              chosen = `type:${m[1]}`;
+            } else {
+              // Fallback to simple prefix detection without scope
+              for (const prefix of Object.keys(map)) {
+                if (title.startsWith(prefix)) { chosen = map[prefix]; break; }
+              }
             }
             if (!chosen) {
               core.info('No type:* inferred from title');

--- a/.github/workflows/pr-body-guard.yml
+++ b/.github/workflows/pr-body-guard.yml
@@ -1,7 +1,7 @@
 name: PR Body Guard
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, ready_for_review]
 concurrency:
   group: pr-body-guard-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
@@ -36,17 +36,28 @@ jobs:
             const missing = required.filter(h => !body.includes(h));
             core.setOutput('missing', JSON.stringify(missing));
             if (missing.length > 0) {
+              const marker = '[PR Body Guard]';
               const msg = [
+                marker,
                 'PR body is missing required sections:',
-                ...missing.map(s => `- ${s.replace(/^##\\s*/,'')}`),
+                ...missing.map(s => `- ${s.replace(/^##\s*/,'')}`),
                 '',
                 'Please fill out the repository PR template sections for consistency.'
               ].join('\n');
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr.number,
-                body: msg
+              const owner = context.repo.owner;
+              const repo = context.repo.repo;
+              const comments = await github.rest.issues.listComments({
+                owner, repo, issue_number: pr.number, per_page: 100
               });
+              const existing = comments.data.find(c => (c.user?.type === 'Bot' || c.user?.login?.includes('github-actions')) && (c.body || '').includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: existing.id, body: msg
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: pr.number, body: msg
+                });
+              }
               core.setFailed(`Missing sections: ${missing.join(', ')}`);
             }


### PR DESCRIPTION
## Summary
Add a PR body guard workflow that checks required sections and comments/fails when missing, and expand PR labeling to infer `type:*` labels from title prefixes (feat/fix/chore/docs/refactor/perf/test). All actions are SHA‑pinned.

## Linked Issue(s)
Closes #NN

## Type of Change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [x] Chore / CI

## Changes
- Add PR Body Guard workflow:
  - Validates required sections: Summary, Linked Issue(s), Type of Change, Changes, Verification, Security Considerations, Risk & Rollback, Checklist
  - Posts a guidance comment and fails the check if sections are missing
  - Uses actions/github-script (SHA‑pinned), runs on `pull_request_target`
- Expand PR labeling:
  - Infer `type:*` from PR title prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`, `perf:`, `test:`
  - Ensures only one `type:*` label is present per PR (replaces others)
  - Implemented via github-script (SHA‑pinned) in the labeler workflow
- Keep labeler robustness:
  - If actions/labeler fails, run fallback; fail the job only if both fail
  - Labeler pinned to Node 24‑compatible version

## Verification
- Lint: ruff passed
- Type: mypy passed
- Tests: pytest passed and coverage gate (>=80%) met
- Security: CodeQL/Trivy checks pass
- Manual checks:
  - Open a PR with missing sections → Body Guard comments and fails
  - Edit PR body to include all sections → Body Guard passes
  - Rename title to `feat: ...` / `fix: ...` etc. → `type:*` label updates accordingly

## Security Considerations
- Data handling/PII impact: None
- Secrets/credentials exposure risk: None (no secrets introduced; actions are SHA‑pinned)
- Dependency or supply‑chain changes: Adds github‑script usage with pinned commit
- Network/attack surface changes: None

## Risk & Rollback
- Risk: Low (CI‑only). First runs may add a comment/failing check if template sections are missing
- Rollback: Remove or disable `.github/workflows/pr-body-guard.yml` and the `type:*` labeling block in `.github/workflows/labeler.yml`

## Breaking Changes
- [x] None
- If any, describe migration notes here

## Release Notes
- CI: add PR body guard (template section check with guidance comment)
- CI: infer and enforce a single `type:*` label from PR title

## Checklist
- [x] Quality gates (ruff/mypy/pytest/coverage) pass
- [x] Structured logs/metrics impact reviewed
- [x] Docs/README/links updated (if applicable)
- [x] No secrets/credentials in code or logs
- [x] Backward compatibility or migration notes included (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * PR 제목의 접두사에 따라 자동으로 타입(type:*) 라벨을 결정·정리하여 적용하도록 자동화 추가
  * PR 본문에 필수 섹션(요약, 연결 이슈, 변경 유형 등)이 모두 포함되었는지 검사하고, 누락 시 코멘트로 안내하며 검증 실패 처리하는 자동화 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->