### PR TITLE
feat: queue/DLQ/per‑table metrics and optional spans; README metrics

### DIFF
--- a/packages/vertex-forager/README.md
+++ b/packages/vertex-forager/README.md
@@ -135,7 +135,7 @@ print(res)  # RunResult
     - `rows_written_total`
     - `writer_flushes`
     - `errors_total`
-    - `dlq_spooled_files_total`, `dlq_rescued_total`, `dlq_remaining_total`
+    - `dlq_spooled_files_total`, `dlq_rescued_total`, `dlq_remaining_total`, `dlq_spool_failed_total`
   - Histograms:
     - `fetch_duration_s`, `parse_duration_s`, `http_duration_s`, `writer_flush_duration_s`
     - Per table: `writer_flush_duration_s.{table}`, `writer_rows.{table}`

--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -27,7 +27,7 @@ import time
 import itertools
 import httpx
 import os
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager
 from typing import Any, TYPE_CHECKING, cast, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from collections.abc import Sequence, Callable
@@ -247,18 +247,25 @@ class VertexForager:
     @contextmanager
     def _span(self, name: str, **attributes: object) -> Iterator[None]:
         if not self._otel_enabled or self._tracer is None:
-            with nullcontext():
-                yield
+            yield
             return
+        start_span = None
         try:
             start_span = getattr(self._tracer, "start_span", None)
-            if callable(start_span):
-                with start_span(f"vertex_forager.{name}", attributes=attributes):
-                    yield
-            else:
-                yield
         except Exception:
-            # Never fail pipeline due to tracing
+            start_span = None
+        if callable(start_span):
+            cm = None
+            try:
+                cm = start_span(f"vertex_forager.{name}", attributes=attributes)
+            except Exception:
+                cm = None
+            if cm is None:
+                yield
+            else:
+                with cm:
+                    yield
+        else:
             yield
     def _log_structured(self, *, provider: str, dataset: str, symbol: str | None, stage: str, attempt: int | None = None, duration_s: float | None = None) -> None:
         if not self._structured_logs:


### PR DESCRIPTION
## Summary
Add standardized observability: queue-length snapshots, DLQ backlog counters, and per-table writer flush percentiles. Introduce optional tracing spans via an injected tracer (env-toggled), and document metrics in README.

## Linked Issue(s)
Closes #83

## Type of Change
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Chore / CI

## Changes
- Pipeline observability
  - Queue snapshots in metrics_summary: req_q_len_after_producer, req_q_len_after_req_join, pkt_q_len_after_producer, pkt_q_len_after_pkt_join.
  - DLQ counters: dlq_spooled_files_total, dlq_rescued_total, dlq_remaining_total, plus per-table variants (dlq_spooled_files.{table}, dlq_rescued.{table}, dlq_remaining.{table}) and dlq_spool_failed_total.
  - Per-table histograms: writer_flush_duration_s.{table}, writer_rows.{table}.
  - Per-table percentiles (p50/p95/p99) in metrics_summary for writer_flush_duration_s.{table} and writer_rows.{table}.
  - Optional OpenTelemetry-style spans (no hard deps): when VF_OTEL_ENABLED=1 and EngineConfig.tracer.start_span(...) is provided, emit spans for pipeline/fetch/parse/write_flush; default path remains no-op with negligible overhead.
- Documentation
  - README Observability section with metric names/units, queue snapshots, and tracer toggle instructions.

Touched files:
- packages/vertex-forager/src/vertex_forager/core/pipeline.py
- packages/vertex-forager/README.md

## Verification
- Lint: ruff passed
- Type: mypy --strict passed
- Tests: pytest passed (162 tests)
- Security: CodeQL/Trivy expected to run in CI; no new runtime dependencies added
- Manual checks: Local smoke run; structured pipeline_summary contains new metrics; spans observed when tracer is injected and VF_OTEL_ENABLED=1

## Security Considerations
- Data handling/PII impact: None (metrics only; no content exfiltration)
- Secrets/credentials exposure risk: None added
- Dependency or supply-chain changes: None (span hooks rely on optional, user-injected tracer)
- Network/attack surface changes: None

## Risk & Rollback
- Risk: Low — additive metrics and optional spans; default behavior unchanged
- Rollback: Revert the squash commit SHA, or disable VF_OTEL_ENABLED and metrics feature flags

## Breaking Changes
- [x] None

## Release Notes
Add standardized metrics (queue lengths, DLQ backlog, per-table writer flush p50/p95/p99) and optional tracing spans; README documents observability and toggles.

## Checklist
- [x] Quality gates (ruff/mypy/pytest/coverage) pass
- [x] Structured logs/metrics impact reviewed
- [x] Docs/README/links updated
- [x] No secrets/credentials in code or logs
- [x] Backward compatibility or migration notes included (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 선택적 OpenTelemetry 트레이싱 통합으로 주요 파이프라인 단계 모니터링 가능
  * 테이블별 쓰기 지연 및 행 수 등 세부 메트릭 수집과 p50/p95/p99 성능 통계 제공
  * DLQ 관련 카운터를 요약에 포함해 장애 가시성 향상

* **문서**
  * 관찰성 섹션 추가: 메트릭, 히스토그램, 테이블별 통계와 트레이싱 활성화 설정 문서화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->