### PR TITLE
fix: squash CI changes into a single commit (Node 24, publish out-dir, docs)

### DIFF
--- a/.github/workflows/attach-release-assets.yml
+++ b/.github/workflows/attach-release-assets.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
@@ -27,11 +27,15 @@ jobs:
         uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82
 
       - name: Clean dist
-        run: rm -rf packages/vertex-forager/dist/
+        run: rm -rf dist/vertex-forager/
 
       - name: Build wheel/sdist (vertex-forager)
         run: |
-          uv build packages/vertex-forager
+          OUT="${GITHUB_WORKSPACE}/dist/vertex-forager"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+          uv build packages/vertex-forager --out-dir "$OUT"
+          ls -l "$OUT"
 
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
@@ -39,5 +43,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ inputs.tag_name }}
-          files: packages/vertex-forager/dist/*
+          files: dist/vertex-forager/*
           fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       VENV: ${{ github.workspace }}/verify-wheel
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4 pinned
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 pinned
       - name: Cache uv download/build artifacts
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3 pinned
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Initialize CodeQL
         uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ jobs:
       vertex_release_created: ${{ steps.release.outputs['packages/vertex-forager--release_created'] }}
       vertex_tag_name: ${{ steps.release.outputs['packages/vertex-forager--tag_name'] }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38
         id: release
         with:
@@ -29,23 +29,27 @@ jobs:
     if: needs.release.outputs.vertex_release_created == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.10"
       - uses: astral-sh/setup-uv@e06108dd0aef18192324c70427afc47652e63a82
 
       - name: Clean dist
-        run: rm -rf packages/vertex-forager/dist/
+        run: rm -rf dist/vertex-forager/
 
       - name: Build wheel/sdist (vertex-forager)
         run: |
-          uv build packages/vertex-forager
+          OUT="${GITHUB_WORKSPACE}/dist/vertex-forager"
+          rm -rf "$OUT"
+          mkdir -p "$OUT"
+          uv build packages/vertex-forager --out-dir "$OUT"
+          ls -l "$OUT"
 
       - name: Upload assets to GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
         with:
-          files: packages/vertex-forager/dist/*
+          files: dist/vertex-forager/*
           tag_name: ${{ needs.release.outputs.vertex_tag_name }}
 
       - name: Upload to PyPI (optional)
@@ -56,4 +60,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
           uv pip install --system -q "twine==6.*"
-          twine upload --skip-existing packages/vertex-forager/dist/*
+          twine upload --skip-existing dist/vertex-forager/*

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -17,7 +17,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:

--- a/packages/vertex-forager/README.md
+++ b/packages/vertex-forager/README.md
@@ -50,6 +50,9 @@ pip install vertex-forager
 
 # Using uv
 uv pip install vertex-forager
+
+# Install from GitHub release asset (specific tag)
+pip install https://github.com/coolbress/VertexLab/releases/download/vertex-forager-v0.2.0/vertex_forager-0.2.0-py3-none-any.whl
 ```
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Squashes recent CI changes into a single commit for a clean history:
  - Upgrade actions runtime to Node 24 (remove Node 20 deprecation warnings)
  - Align publish chain to explicit out-dir (dist/vertex-forager)
  - Add release install example to README
  - Pin actions/checkout to v5 SHA

## Type of Change
- [x] ci/chore
- [x] fix
- [ ] docs
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test

## Verification
- Workflows run green on latest main
- Attach Release Assets and publish chain both use dist/vertex-forager/*
- Release asset install validated and __version__ == 0.2.0

## Risk & Rollback
- Low (workflow/README only). Rollback by reverting this PR.

## Breaking Change?
- [ ] Yes
- [x] No

## Checklist
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * GitHub 릴리스 휠에서 설치하는 방법에 대한 설명을 추가했습니다.

* **Chores**
  * 빌드 및 배포 워크플로우를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->