### PR TITLE
chore: labeler proof (docs)

### DIFF
--- a/docs/labeler-proof.md
+++ b/docs/labeler-proof.md
@@ -1,0 +1,7 @@
+---
+title: Labeler Proof (Temporary)
+---
+
+This file exists solely to trigger the path-based labeler for docs changes.
+It can be removed after verifying that labels are applied on a test PR.
+


### PR DESCRIPTION
This PR adds a temporary docs file to verify path-based labeling (area:docs) and type:* from title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * 새로운 설명서 파일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->