### PR TITLE
docs: add Pre-0.2.0 historical section to CHANGELOG 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Replace pickle serialization in library fetch with Arrow/Polars IPC; JSON fallback  (#49)
 - Validate EngineConfig at construction; remove DuckDBWriter globals; unify pipeline orchestration  (#48)
 - Dead code cleanup, exception consistency, concurrency validation  (#42)
-- types(mypy): strict baseline for vertex-forager; minimal fixes  (#38)
+- Strict mypy baseline for vertex-forager; minimal fixes  (#38)
 - Add Tuning CLI and Optimize Hotspots (#29)
 - Apply DIP, add library fetcher registry, extend yfinance, strengthen CI/docs (#23)
 - Refactor: Strengthen type safety and introduce generics across routers/clients (#20)


### PR DESCRIPTION
## Summary

- Backfill a single “Pre-0.2.0 (Historical)” section in CHANGELOG.md, grouping merged PRs into Added/Changed/Fixed/Docs/Internal.
- Excludes items labeled `no-changelog`. v0.2.0 remains the first official release (no retro tags created).

## Linked Issue

- N/A

## Type of Change

- [x] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] ci/chore

## Changes

- Add “Pre-0.2.0 (Historical)” block to CHANGELOG.md.
- Classify historical PRs by standardized titles/labels.
- Docs-only change; no code paths modified.

## Verification

- Ran local checks: ruff/pytest passed.
- Confirmed entries are limited to PRs merged before `vertex-forager-v0.2.0`.
- Verified `no-changelog` items are excluded.

## Security Considerations

- None. Documentation-only; no secrets, dependencies, or permissions affected.

## Risk & Rollback

- Low risk. Rollback by reverting the CHANGELOG.md update.

## Checklist

- [x] ruff/mypy/pytest pass locally
- [x] Docs updated (user‑visible)
- [x] Changelog entry (user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **문서**
  * 변경 로그에 "[Pre-0.2.0] - Historical" 하위 섹션을 추가하고 과거 항목들을 Added/Changed/Fixed/Docs/Internal로 재분류하여 역사적 변경 내역 가독성 향상.
  * 여러 과거의 추가·변경·수정·문서 항목을 해당 역사 섹션으로 통합 정리해 릴리스 기록이 더 명확해짐.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->