### PR TITLE
chore: pin checkout@v5 SHA in actionlint and dependabot automerge; align concurrency

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 pinned
       - name: Run actionlint
         uses: devops-actions/actionlint@469810fd82c015d3c43815cd2b0e4d02eecc4819

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     types: [opened, synchronize, labeled, unlabeled, ready_for_review]
 
+concurrency:
+  group: automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   automerge:
     if: |
@@ -22,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 pinned
         with:
           fetch-depth: 0
       - name: Restrict to workflow changes only


### PR DESCRIPTION
## Summary
- What does this change do?
  - Pins actions/checkout to v5 (SHA-pinned) in actionlint.yml and dependabot-automerge.yml, and aligns concurrency settings where applicable.
- Why is it needed?
  - Ensures consistent, secure, and predictable workflow behavior across the repository, reducing supply-chain risk and avoiding version drift.

## Linked Issue
- Closes #135

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [x] ci/chore

## Changes
- actionlint.yml: update actions/checkout to v5 (SHA-pinned).
- dependabot-automerge.yml: update actions/checkout to v5 (SHA-pinned).
- dependabot-automerge.yml: add concurrency group (automerge-${{ github.event.pull_request.number }}) with cancel-in-progress: true.
- Permissions remain minimal and appropriate for each job; triggers unchanged.

## Verification
- Actionlint passes locally and on CI for updated workflows.
- Workflows load successfully on GitHub Actions with v5 checkout.
- Dependabot automerge job concurrency behaves as expected for concurrent PR events.

## Security Considerations
- No secrets or PII introduced.
- SHA-pinned Actions reduce supply-chain risk.
- Workflow permissions unchanged (least-privilege maintained).

## Risk & Rollback
- Risk: Low
- Rollback: revert the specific workflow files to previous checkout versions and remove the added concurrency group if necessary.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- actionlint: OK
- Workflow syntax validation: OK

## Checklist
- [ ] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * GitHub Actions 워크플로우의 체크아웃 액션 버전을 업데이트하여 최신 상태를 유지합니다.
  * 자동 병합 워크플로우에 동시성 제어를 추가하여 작업 순서를 안정화합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->