### PR TITLE
feat: add per-request idempotent flag to guard retries 

### DIFF
--- a/packages/vertex-forager/README.md
+++ b/packages/vertex-forager/README.md
@@ -285,6 +285,19 @@ from vertex_forager import (
     Non-idempotent requests (e.g., POST/PUT without idempotency keys) can cause duplicate side effects.
     Use idempotency keys or ensure upstream idempotent semantics before opting in.
 
+### Per-request Idempotency Flag
+
+- Each RequestSpec now supports `idempotent: bool` (default `True`).
+- When `idempotent=False`, the retry controller performs a single attempt (no retry), even if transport/status rules match.
+- Example:
+
+```python
+from vertex_forager.core.config import RequestSpec
+
+# Non-idempotent request — do not retry
+spec = RequestSpec(url="https://api.example.com/submit", method="POST", json_body={"x": 1}, idempotent=False)
+```
+
 ## License
 
 MIT

--- a/packages/vertex-forager/src/vertex_forager/core/config.py
+++ b/packages/vertex-forager/src/vertex_forager/core/config.py
@@ -111,6 +111,9 @@ class RequestSpec(BaseModel):
         data: Raw bytes payload for requests (default: None).
         timeout_s: Request timeout in seconds (default: 30.0).
         auth: Authentication strategy to apply (default: RequestAuth()).
+        idempotent: Whether the request is safe to retry without side effects.
+            Defaults to True to preserve existing behavior; set to False to disable
+            automatic retries for non-idempotent operations.
     """
 
     method: HttpMethod = HttpMethod.GET
@@ -121,6 +124,7 @@ class RequestSpec(BaseModel):
     data: bytes | None = None
     timeout_s: float = HTTP_TIMEOUT_S
     auth: RequestAuth = Field(default_factory=RequestAuth)
+    idempotent: bool = True
 
     @field_validator("params", mode="before")
     @classmethod

--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -1361,7 +1361,8 @@ class VertexForager:
             This guarantees that the physical request rate (RPM) never exceeds the limit,
             even if one "logical" user request expands into hundreds of API calls.
         """
-        retry_controller = create_retry_controller(self._config.retry)
+        # Honor per-request idempotency: non-idempotent requests should not retry.
+        retry_controller = create_retry_controller(self._config.retry, idempotent=job.spec.idempotent)
 
         async for attempt in retry_controller:
             with attempt:

--- a/packages/vertex-forager/src/vertex_forager/core/retry.py
+++ b/packages/vertex-forager/src/vertex_forager/core/retry.py
@@ -23,6 +23,8 @@ logger = logging.getLogger("vertex_forager.retry")
 
 def create_retry_controller(
     config: RetryConfig,
+    *,
+    idempotent: bool = True,
     log_level: int = logging.WARNING,
     retry_on: tuple[type[Exception], ...] = (httpx.TransportError,),
 ) -> AsyncRetrying:
@@ -57,8 +59,11 @@ def create_retry_controller(
         rnd = secrets.SystemRandom()
         return float(rnd.uniform(0.0, cap))
 
+    # For non-idempotent requests, guard against repeats by forcing a single attempt.
+    stop_policy = stop_after_attempt(1 if not idempotent else config.max_attempts)
+
     return AsyncRetrying(
-        stop=stop_after_attempt(config.max_attempts),
+        stop=stop_policy,
         wait=_wait_capped,
         retry=retry_if_exception(_should_retry),
         before_sleep=before_sleep_log(logger, log_level),

--- a/packages/vertex-forager/tests/integration/test_retry_pipeline_http_status.py
+++ b/packages/vertex-forager/tests/integration/test_retry_pipeline_http_status.py
@@ -117,3 +117,26 @@ async def test_fetch_with_retry_logs_and_succeeds_on_429_then_200(
         "stage=http_retry" in m or "stage=http_retry_reason" in m for m in messages
     )
     assert any("stage=http_end" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_fetch_without_retry_when_non_idempotent() -> None:
+    stub_client = StubClient()
+    http = HttpExecutor(client=stub_client)
+    pipeline = VertexForager(
+        router=StubRouter(),
+        http=http,
+        writer=StubWriter(),
+        mapper=StubMapper(),
+        config=stub_client._config,
+        controller=stub_client.controller,
+    )
+    # First call returns 429 in StubClient; non-idempotent must not retry.
+    job = FetchJob(
+        provider="stub",
+        dataset="price",
+        symbol="AAPL",
+        spec=RequestSpec(url="https://example.com", idempotent=False),
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        await pipeline._fetch_with_retry(job)

--- a/uv.lock
+++ b/uv.lock
@@ -3009,7 +3009,7 @@ source = { editable = "packages/vertex-caliber" }
 
 [[package]]
 name = "vertex-forager"
-version = "0.2.2"
+version = "0.3.0"
 source = { editable = "packages/vertex-forager" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- What does this change do?
  - Adds `idempotent: bool` to RequestSpec and honors it in the retry controller.
  - When `idempotent=False`, the request is attempted once (no retry), even if status/transport rules would normally retry.
- Why is it needed?
  - Prevents duplicate side effects for non-idempotent operations, while preserving retries for idempotent requests.

## Linked Issue
- Closes #156 

## Type of Change
- [ ] docs
- [ ] fix
- [x] feat
- [ ] refactor
- [ ] perf
- [x] test
- [ ] ci/chore

## Changes
- Core
  - RequestSpec: add `idempotent: bool` (default `True`) [core/config.py]
  - Retry: `create_retry_controller(idempotent=...)` forces 1 attempt when non-idempotent [core/retry.py]
  - Pipeline: pass per-request idempotency to retry controller [core/pipeline.py]
- Tests
  - Add integration test to assert no retry when `idempotent=False` (first 429 yields failure)
- Docs
  - README: document the per-request idempotency flag and usage example

## Verification
- Local checks:
  - `uv run ruff check packages/` — pass
  - `uv run mypy packages/vertex-forager/src --strict` — pass
  - `uv run pytest -q` — all tests pass
- Behavior:
  - Idempotent request: retries on 429 then succeeds
  - Non-idempotent request: single attempt, 429 raises without retry

## Security Considerations
- No secrets or PII added.
- No new external permissions; behavior is internal to retry controller.

## Risk & Rollback
- Risk: Low (flag-based and default preserves current behavior).
- Rollback: Remove `idempotent` from RequestSpec and related logic in retry controller/pipeline.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- N/A

## Checklist
- [x] ruff/mypy/pytest pass locally
- [x] Docs updated (user-visible)
- [x] Changelog entry (if applicable)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요청별 멱등성 제어 추가: 요청 구성에서 `idempotent` 플래그를 False로 설정하면 자동 재시도가 비활성화됩니다.

* **문서**
  * 멱등성이 없는 요청의 처리 방법과 예제를 포함한 설명서 업데이트.

* **테스트**
  * 멱등성이 없는 요청이 재시도되지 않는 동작을 검증하는 통합 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->