### PR TITLE
fix: respect show_progress in SharadarClient 

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py
@@ -150,6 +150,7 @@ class SharadarClient(BaseClient[SharadarDataset]):
         *,
         tickers: list[str] | None = None,
         connect_db: str | Path | None = None,
+        show_progress: bool = True,
         **kwargs: object,
     ) -> pl.DataFrame | RunResult:
         """Fetch metadata for all or specific tickers (TICKERS).
@@ -157,6 +158,7 @@ class SharadarClient(BaseClient[SharadarDataset]):
         Args:
             tickers: Optional list of ticker symbols to filter. If None, fetches all.
             connect_db: Optional DuckDB connection string/path for persistence.
+            show_progress: Whether to display progress indicators (default: True).
             **kwargs: Additional provider-specific options forwarded to the pipeline.
 
         Returns:
@@ -168,7 +170,12 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return await self._get_ticker_info_impl(tickers=tickers, connect_db=connect_db, show_spinner=True, **kwargs)
+        return await self._get_ticker_info_impl(
+            tickers=tickers,
+            connect_db=connect_db,
+            show_spinner=show_progress,
+            **kwargs,
+        )
 
     @jupyter_safe
     async def get_sp500_history(


### PR DESCRIPTION
## Summary
- Honor user-supplied show_progress in all SharadarClient public fetch methods.
- Ensures progress indicators can be suppressed consistently when requested.

## Linked Issue
- Closes #170

## Type of Change
- [ ] docs
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] ci/chore

## Changes
- Add show_progress parameter to SharadarClient public fetch methods and pass through to FetchConfig.
- Make metadata prefetch spinner respect show_progress.

## Verification
- uv run ruff check packages/vertex-forager/ --fix
- uv run mypy packages/vertex-forager/src --strict
- uv run pytest packages/vertex-forager/tests -q

## Security Considerations
- No secrets/PII. No dependency or permissions changes.

## Risk & Rollback
- Low risk. Roll back by reverting this commit.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- N/A

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sharadar 클라이언트 주요 데이터 조회 메서드에 진행률 표시 제어 기능 추가.
  * get_price_data, get_fundamental_data, get_daily_metrics, get_corporate_actions, get_insider_trading, get_institutional_ownership, get_sp500_history 및 티커 정보 조회에 show_progress(bool, 기본값: True) 파라미터 추가.
  * 진행률 표시 비활성화 시 스피너가 표시되지 않도록 동작 수정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->