### PR TITLE
chore: add Python 3.10–3.13 matrix and non-blocking benchmark 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,11 +214,11 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 pinned
       - name: Install uv
-        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v5 pinned
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v5 pinned
         with:
           python-version: "3.10"
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- What does this change do?
  - Runs CI on Python 3.10, 3.11, 3.12, and 3.13.
  - Keeps full quality gates on 3.10; runs fast tests on 3.11–3.13.
  - Adds a non‑blocking performance benchmark on main pushes (report‑only).
- Why is it needed?
  - The project declares requires‑python >=3.10, but CI only verified 3.10.
  - Ensures compatibility across 3.11–3.13 and provides early visibility into performance regressions without blocking merges.

## Linked Issue
- Closes #163

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [x] ci/chore

## Changes
- Add strategy.matrix.python-version: ["3.10", "3.11", "3.12", "3.13"].
- On 3.10:
  - Trivy secret/misconfig scan with SARIF upload on pushes to main.
  - Ruff lint (tier‑1 blocking; tier‑2 non‑blocking), YAML lint.
  - Pytest with coverage gate; build sdist/wheel and smoke‑install.
  - pip‑audit on the venv used for smoke install.
- On 3.11–3.13:
  - Run pytest for quick compatibility checks.
- Main push only:
  - Run verify_pipeline_perf.py as a non‑blocking benchmark; continue‑on‑error: true.

## Verification
- Local
  - uv run ruff check packages/ --exclude "legacy_code"
  - uv run mypy packages/vertex-forager/src --strict
  - uv run pytest packages/vertex-forager/tests -q
- CI
  - Matrix executes on PRs and main pushes.
  - 3.10 runs full gates; 3.11–3.13 run tests only.
  - Benchmark step runs only on main push and does not block.

## Security Considerations
- No secrets or PII added.
- No new permissions requested.
- Trivy and pip‑audit continue to improve supply‑chain hygiene.
- Actions remain SHA‑pinned.

## Risk & Rollback
- Risk: Low. Increased CI time mitigated by limiting full gates to 3.10.
- Rollback: Revert .github/workflows/ci.yml to the previous single‑version setup.

## Breaking Change?
- [ ] Yes (backward‑incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- N/A

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI 워크플로우를 Python 3.10–3.13 매트릭스로 확장(페일패스트 비활성화)하고 잡 표시명에 Python 버전 포함.
  * Python 설치에 매트릭스 변수 사용.
  * Trivy 보안 스캔과 SARIF 업로드, 주요 보안 게이트 및 무거운 품질 검사(린트·커버리지·패키지 빌드·pip-audit 등)를 3.10 레그 전용으로 제한.
  * 비-3.10 레그는 특정 테스트 폴더에 대한 경량 pytest만 실행하도록 변경.
  * quality-check 후 매트릭스 결과를 검증하는 quality-gate 잡 추가.
  * main 푸시 시 실행되는 비차단(continue-on-error) 벤치마크 잡 추가(quality-check 의존, 3.10 실행).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->