### PR TITLE
fix(controller): measure RTT after slot acquisition to exclude queue wait (#181)

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/controller.py
+++ b/packages/vertex-forager/src/vertex_forager/core/controller.py
@@ -67,6 +67,7 @@ class GradientConcurrencyLimiter:
     async def release(self, rtt: float) -> None:
         """Release a slot and update the concurrency limit based on RTT."""
         async with self._condition:
+            self._rtt_samples.append(rtt)
             self._update_limit(rtt)
             self.inflight -= 1
             self._condition.notify()

--- a/packages/vertex-forager/tests/unit/test_controller_throttle_rtt.py
+++ b/packages/vertex-forager/tests/unit/test_controller_throttle_rtt.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import statistics
 
 import pytest
 
@@ -16,10 +17,15 @@ async def test_throttle_rtt_excludes_queue_wait() -> None:
             await asyncio.sleep(0.2)
 
     t1 = asyncio.create_task(worker())
-    await asyncio.sleep(0)  # schedule second task while first holds the slot
+    await asyncio.sleep(0)
     t2 = asyncio.create_task(worker())
     await asyncio.gather(t1, t2)
 
     rtt = float(ctrl._concurrency_limiter.rtt_ema)
     assert rtt >= 0.15
     assert rtt < 0.3
+    raw = list(ctrl._concurrency_limiter._rtt_samples)
+    assert len(raw) >= 2
+    assert max(raw) < 0.3
+    assert statistics.median(raw) < 0.3
+    assert min(raw) >= 0.15


### PR DESCRIPTION
## Summary
- What does this change do?
  - Moves RTT timing start to after the concurrency slot is acquired so only actual HTTP RTT is measured by the GradientConcurrencyLimiter.
  - Adds a unit test to verify queue wait time is excluded from rtt_ema.
- Why is it needed?
  - Including queue wait inflated rtt_ema under contention, lowering the gradient and reducing concurrency unnecessarily, harming throughput (10–30% in sustained load).

## Linked Issue
- Closes #181

## Type of Change
- [x] fix
- [x] test
- [ ] docs
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] ci/chore

## Changes
- FlowController.throttle(): start_time is captured after _concurrency_limiter.acquire(); rtt fed back excludes queue wait.
- Add test_controller_throttle_rtt.py to assert rtt_ema approximates actual work (~0.2s) even when a second coroutine queues.
- No public API changes.

## Verification
- Local:
  - uv run pytest -q -m "not manual"
  - Result: 283 passed, 4 deselected
- Targeted:
  - uv run pytest packages/vertex-forager/tests/unit/test_controller_throttle_rtt.py -q

## Security Considerations
- No secrets, PII, or new dependencies.
- No permission changes.

## Risk & Rollback
- Risk: Low. Behavior aligns RTT measurement with intended design.
- Rollback: Revert this commit. Temporary workaround available by pinning EngineConfig(concurrency=N).

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- pytest: 283 passed, 4 deselected

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 동시성 제한기의 왕복시간(RTT) 측정을 개선하여 큐 대기 시간을 제외하고 실제 처리 시간만 반영하도록 수정했습니다. 이로 인해 적응적 동시성 조절의 피드백이 더 정확해집니다.

* **테스트**
  * RTT 측정이 큐 대기 시간을 올바르게 제외하는지를 검증하는 단위 테스트를 추가하여 회귀를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->