### PR TITLE
fix(verification): guard yfinance perf verification when optional deps are missing

### DIFF
--- a/packages/vertex-forager/tests/verification/verify_pipeline_perf.py
+++ b/packages/vertex-forager/tests/verification/verify_pipeline_perf.py
@@ -2,7 +2,6 @@ import json
 import os
 from pathlib import Path
 
-from vertex_forager.providers.yfinance.client import YFinanceClient
 from vertex_forager.utils import as_dict
 
 
@@ -29,14 +28,28 @@ def main() -> None:
     if db_path.exists():
         db_path.unlink()
 
+    try:
+        from vertex_forager.providers.yfinance.client import YFinanceClient
+    except ImportError as err:
+        if err.name in {"pandas", "yfinance"}:
+            print("Skipping verification: install optional deps with `pip install vertex-forager[yfinance]`")
+            return
+        raise
+
     client = YFinanceClient(rate_limit=60, metrics_enabled=True, structured_logs=False)
     tickers = ["AAPL", "MSFT", "NVDA", "GOOGL", "AMZN"]
 
-    run = client.get_price_data(
-        tickers=tickers,
-        connect_db=db_path,
-        show_progress=False,
-    )
+    try:
+        run = client.get_price_data(
+            tickers=tickers,
+            connect_db=db_path,
+            show_progress=False,
+        )
+    except ImportError as err:
+        if err.name in {"pandas", "yfinance"}:
+            print("Skipping verification: install optional deps with `pip install vertex-forager[yfinance]`")
+            return
+        raise
 
     data = as_dict(run)
     metrics_path.write_text(json.dumps(data, indent=2))


### PR DESCRIPTION
## Summary
- **What does this change do?**
  - Updates `verify_pipeline_perf.py` to gracefully handle missing optional yfinance dependencies (`pandas`, `yfinance`) instead of hard-failing.
  - Moves yfinance client import into runtime path and adds explicit `ImportError` handling with a skip-style message.
  - Preserves normal verification behavior when optional dependencies are installed.

- **Why is it needed?**
  - Main branch verification failed in CI/bare installs because `pandas` is now optional.
  - Verification scripts should not fail merge checks just because optional extras are absent.

## Linked Issue
- N/A

## Type of Change
- [ ] docs
- [x] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [x] test
- [x] ci/chore

## Changes
- Updated `packages/vertex-forager/tests/verification/verify_pipeline_perf.py`:
  - Runtime import guard for `YFinanceClient`.
  - Skip-style early return when optional deps are missing (`pandas` / `yfinance`).
  - Added equivalent guard around the execution path to avoid runtime import crashes.
- No changes to core data-fetch behavior when extras are installed.

## Verification
- Ran:
  - `uv run ruff check packages/vertex-forager/tests/verification/verify_pipeline_perf.py --fix`
  - `uv run python packages/vertex-forager/tests/verification/verify_pipeline_perf.py`
  - `uv run mypy packages/vertex-forager/src --strict`
- Result:
  - Ruff passed.
  - MyPy strict passed.
  - Verification script completed without optional-dependency hard failure.

## Security Considerations
- No secrets/PII introduced.
- No permission model changes.
- Reduces CI fragility without widening dependency trust surface.

## Risk & Rollback
- **Risk level:** Low
- **Rollback:** Revert changes in `verify_pipeline_perf.py` to previous import/execute behavior.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Example behavior when optional deps are missing:
  - Script prints guidance and exits cleanly instead of raising `ModuleNotFoundError`.

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 누락된 의존성에 대한 오류 처리 개선. `pandas` 또는 `yfinance` 누락 시 명확한 설치 가이드 메시지 표시.
  * 실행 중 의존성 검증으로 초기화 오류 감지 능력 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->