### PR TITLE
refactor: simplify scheduler API and close fairness follow-up gaps (#238)

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -103,6 +103,7 @@ from vertex_forager.core.retry import (
 )
 from vertex_forager.core.scheduler import (
     FairnessState,
+    SchedulerResult,
 )
 from vertex_forager.core.scheduler import (
     pop_next_job_respecting_fairness as pop_next_job_respecting_fairness_impl,
@@ -1176,17 +1177,15 @@ class VertexForager:
         fair_lock = self._fair_lock
         if fair_lock is None:
             raise RuntimeError("Fairness lock must be initialized before use")
-        priority, job, demote_jobs, already_done, _, _ = (
-            await pop_next_job_respecting_fairness_impl(
-                req_q=req_q,
-                fair_lock=fair_lock,
-                burst_cap=burst_cap,
-                priority_pagination=self.PRIORITY_PAGINATION,
-                priority_new_job=self.PRIORITY_NEW_JOB,
-                fairness_state=self._fair_state,
-            )
+        selected: SchedulerResult = await pop_next_job_respecting_fairness_impl(
+            req_q=req_q,
+            fair_lock=fair_lock,
+            burst_cap=burst_cap,
+            priority_pagination=self.PRIORITY_PAGINATION,
+            priority_new_job=self.PRIORITY_NEW_JOB,
+            fairness_state=self._fair_state,
         )
-        return priority, job, demote_jobs, already_done
+        return selected.priority, selected.job, selected.demoted, selected.already_done
 
     async def _fetch_worker(
         self,

--- a/packages/vertex-forager/src/vertex_forager/core/scheduler.py
+++ b/packages/vertex-forager/src/vertex_forager/core/scheduler.py
@@ -21,6 +21,14 @@ class FairnessState:
     burst_count: int = 0
 
 
+@dataclass(frozen=True)
+class SchedulerResult:
+    priority: int
+    job: FetchJob | None
+    demoted: list[FetchJob]
+    already_done: bool
+
+
 async def pop_next_job_respecting_fairness(
     *,
     req_q: asyncio.PriorityQueue[tuple[int, int, FetchJob | None]],
@@ -28,10 +36,8 @@ async def pop_next_job_respecting_fairness(
     burst_cap: int,
     priority_pagination: int,
     priority_new_job: int,
-    fairness_state: FairnessState | None = None,
-    fair_last_symbol: str | None = None,
-    fair_burst_count: int = 0,
-) -> tuple[int, FetchJob | None, list[FetchJob], bool, str | None, int]:
+    fairness_state: FairnessState,
+) -> SchedulerResult:
     """Select the next queue item while enforcing pagination burst fairness.
 
     Args:
@@ -44,50 +50,41 @@ async def pop_next_job_respecting_fairness(
         priority_pagination: Priority value used for paginated follow-up jobs.
         priority_new_job: Priority value used when demoted jobs should be
             requeued as normal jobs.
-        fairness_state: Shared mutable fairness state. When provided, this
-            object is updated in-place under fair_lock.
-        fair_last_symbol: Backward-compatible seed value for last symbol when no
-            shared fairness_state is provided.
-        fair_burst_count: Backward-compatible seed value for burst count when no
-            shared fairness_state is provided.
+        fairness_state: Shared mutable fairness state, updated in-place under
+            fair_lock.
 
     Returns:
-        A tuple of:
-        - selected priority
-        - selected FetchJob or None (sentinel/defer path)
-        - demoted jobs that caller should requeue at priority_new_job
-        - already_done flag indicating task_done was already called for selected
+        SchedulerResult:
+        - priority: selected priority
+        - job: selected FetchJob or None (sentinel/defer path)
+        - demoted: jobs caller should requeue at priority_new_job
+        - already_done: True when task_done was already called for selected
           sentinel
-        - updated fair_last_symbol
-        - updated fair_burst_count
 
     Side effects:
         - Reads/removes items from req_q.
-        - Updates fairness_state when provided.
+        - Updates fairness_state in-place.
         - Calls req_q.task_done() for consumed sentinels.
     """
     demote_jobs: list[FetchJob] = []
     already_done = False
-    state = fairness_state if fairness_state is not None else FairnessState(
-        last_symbol=fair_last_symbol,
-        burst_count=fair_burst_count,
-    )
+    state = fairness_state
     async with fair_lock:
         priority, _, job = await req_q.get()
         if job is None:
             req_q.task_done()
-            return priority, None, demote_jobs, True, state.last_symbol, state.burst_count
+            return SchedulerResult(priority=priority, job=None, demoted=demote_jobs, already_done=True)
         if priority != priority_pagination:
             state.last_symbol = None
             state.burst_count = 0
-            return priority, job, demote_jobs, already_done, state.last_symbol, state.burst_count
+            return SchedulerResult(priority=priority, job=job, demoted=demote_jobs, already_done=already_done)
         if state.last_symbol == job.symbol:
             state.burst_count += 1
         else:
             state.last_symbol = job.symbol
             state.burst_count = 1
         if state.burst_count <= burst_cap:
-            return priority, job, demote_jobs, already_done, state.last_symbol, state.burst_count
+            return SchedulerResult(priority=priority, job=job, demoted=demote_jobs, already_done=already_done)
         demote_jobs.append(job)
         return _pick_after_demotion(
             req_q=req_q,
@@ -107,18 +104,16 @@ def _pick_after_demotion(
     priority_pagination: int,
     priority_new_job: int,
     fairness_state: FairnessState,
-) -> tuple[int, FetchJob | None, list[FetchJob], bool, str | None, int]:
+) -> SchedulerResult:
     while True:
         try:
             p2, order2, cand = req_q.get_nowait()
         except asyncio.QueueEmpty:
-            return (
-                priority_new_job,
-                None,
-                demote_jobs,
-                already_done,
-                fairness_state.last_symbol,
-                fairness_state.burst_count,
+            return SchedulerResult(
+                priority=priority_new_job,
+                job=None,
+                demoted=demote_jobs,
+                already_done=already_done,
             )
         if p2 == priority_pagination and cand is not None and cand.symbol == fairness_state.last_symbol:
             # Do not call req_q.task_done() here: demoted jobs are acknowledged after requeue in
@@ -129,20 +124,18 @@ def _pick_after_demotion(
             if demote_jobs:
                 req_q.task_done()
                 req_q.put_nowait((p2, order2, None))
-                return (
-                    priority_new_job,
-                    None,
-                    demote_jobs,
-                    already_done,
-                    fairness_state.last_symbol,
-                    fairness_state.burst_count,
+                return SchedulerResult(
+                    priority=priority_new_job,
+                    job=None,
+                    demoted=demote_jobs,
+                    already_done=already_done,
                 )
             req_q.task_done()
-            return p2, None, demote_jobs, True, fairness_state.last_symbol, fairness_state.burst_count
+            return SchedulerResult(priority=p2, job=None, demoted=demote_jobs, already_done=True)
         if p2 == priority_pagination:
             fairness_state.last_symbol = cand.symbol
             fairness_state.burst_count = 1
         else:
             fairness_state.last_symbol = None
             fairness_state.burst_count = 0
-        return p2, cand, demote_jobs, already_done, fairness_state.last_symbol, fairness_state.burst_count
+        return SchedulerResult(priority=p2, job=cand, demoted=demote_jobs, already_done=already_done)

--- a/packages/vertex-forager/tests/unit/test_core_scheduler.py
+++ b/packages/vertex-forager/tests/unit/test_core_scheduler.py
@@ -5,7 +5,7 @@ import asyncio
 import pytest
 
 from vertex_forager.core.config import FetchJob, RequestSpec
-from vertex_forager.core.scheduler import pop_next_job_respecting_fairness
+from vertex_forager.core.scheduler import FairnessState, pop_next_job_respecting_fairness
 
 
 def _job(symbol: str) -> FetchJob:
@@ -21,21 +21,21 @@ def _job(symbol: str) -> FetchJob:
 async def test_pop_next_job_respecting_fairness_consumes_sentinel() -> None:
     req_q: asyncio.PriorityQueue[tuple[int, int, FetchJob | None]] = asyncio.PriorityQueue()
     req_q.put_nowait((99, 0, None))
-    priority, job, demotes, done, last_symbol, burst_count = await pop_next_job_respecting_fairness(
+    state = FairnessState()
+    result = await pop_next_job_respecting_fairness(
         req_q=req_q,
         fair_lock=asyncio.Lock(),
         burst_cap=2,
         priority_pagination=1,
         priority_new_job=0,
-        fair_last_symbol=None,
-        fair_burst_count=0,
+        fairness_state=state,
     )
-    assert priority == 99
-    assert job is None
-    assert demotes == []
-    assert done is True
-    assert last_symbol is None
-    assert burst_count == 0
+    assert result.priority == 99
+    assert result.job is None
+    assert result.demoted == []
+    assert result.already_done is True
+    assert state.last_symbol is None
+    assert state.burst_count == 0
 
 
 @pytest.mark.asyncio
@@ -44,19 +44,77 @@ async def test_pop_next_job_respecting_fairness_demotes_excess_burst() -> None:
     req_q.put_nowait((1, 0, _job("AAPL")))
     req_q.put_nowait((1, 1, _job("AAPL")))
     req_q.put_nowait((2, 2, _job("MSFT")))
-    priority, job, demotes, done, last_symbol, burst_count = await pop_next_job_respecting_fairness(
+    state = FairnessState(last_symbol="AAPL", burst_count=2)
+    result = await pop_next_job_respecting_fairness(
         req_q=req_q,
         fair_lock=asyncio.Lock(),
         burst_cap=2,
         priority_pagination=1,
         priority_new_job=0,
-        fair_last_symbol="AAPL",
-        fair_burst_count=2,
+        fairness_state=state,
     )
-    assert priority == 2
-    assert job is not None
-    assert job.symbol == "MSFT"
-    assert [d.symbol for d in demotes] == ["AAPL", "AAPL"]
-    assert done is False
-    assert last_symbol is None
-    assert burst_count == 0
+    assert result.priority == 2
+    assert result.job is not None
+    assert result.job.symbol == "MSFT"
+    assert [d.symbol for d in result.demoted] == ["AAPL", "AAPL"]
+    assert result.already_done is False
+    assert state.last_symbol is None
+    assert state.burst_count == 0
+
+
+@pytest.mark.asyncio
+async def test_pop_next_job_symbol_change_resets_burst_to_one() -> None:
+    req_q: asyncio.PriorityQueue[tuple[int, int, FetchJob | None]] = asyncio.PriorityQueue()
+    req_q.put_nowait((1, 0, _job("MSFT")))
+    state = FairnessState(last_symbol="AAPL", burst_count=3)
+    result = await pop_next_job_respecting_fairness(
+        req_q=req_q,
+        fair_lock=asyncio.Lock(),
+        burst_cap=10,
+        priority_pagination=1,
+        priority_new_job=0,
+        fairness_state=state,
+    )
+    assert result.job is not None
+    assert result.job.symbol == "MSFT"
+    assert state.last_symbol == "MSFT"
+    assert state.burst_count == 1
+
+
+@pytest.mark.asyncio
+async def test_pop_next_job_empty_queue_after_demotion_returns_no_candidate() -> None:
+    req_q: asyncio.PriorityQueue[tuple[int, int, FetchJob | None]] = asyncio.PriorityQueue()
+    req_q.put_nowait((1, 0, _job("AAPL")))
+    req_q.put_nowait((1, 1, _job("AAPL")))
+    state = FairnessState(last_symbol="AAPL", burst_count=2)
+    result = await pop_next_job_respecting_fairness(
+        req_q=req_q,
+        fair_lock=asyncio.Lock(),
+        burst_cap=2,
+        priority_pagination=1,
+        priority_new_job=0,
+        fairness_state=state,
+    )
+    assert result.priority == 0
+    assert result.job is None
+    assert [d.symbol for d in result.demoted] == ["AAPL", "AAPL"]
+    assert result.already_done is False
+
+
+@pytest.mark.asyncio
+async def test_pop_next_job_mutates_fairness_state_in_place() -> None:
+    req_q: asyncio.PriorityQueue[tuple[int, int, FetchJob | None]] = asyncio.PriorityQueue()
+    req_q.put_nowait((1, 0, _job("TSLA")))
+    state = FairnessState(last_symbol=None, burst_count=0)
+    original_id = id(state)
+    _ = await pop_next_job_respecting_fairness(
+        req_q=req_q,
+        fair_lock=asyncio.Lock(),
+        burst_cap=3,
+        priority_pagination=1,
+        priority_new_job=0,
+        fairness_state=state,
+    )
+    assert id(state) == original_id
+    assert state.last_symbol == "TSLA"
+    assert state.burst_count == 1

--- a/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
+++ b/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
@@ -11,6 +11,9 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+import itertools
+from pathlib import Path
+import time
 from typing import Any
 
 import pytest
@@ -352,3 +355,199 @@ async def test_concurrent_run_raises() -> None:
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+def test_find_latest_checkpoint_skips_corrupted_and_uses_latest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+    root = tmp_path / "vf-root"
+    monkeypatch.setenv("VERTEXFORAGER_ROOT", str(root))
+    cache_root = root / "cache"
+    checkpoints_dir = cache_root / "checkpoints"
+    checkpoints_dir.mkdir(parents=True, exist_ok=True)
+    bad = checkpoints_dir / "bad_checkpoint"
+    old = checkpoints_dir / "stub_d_100"
+    new = checkpoints_dir / "stub_d_200"
+    bad.mkdir(exist_ok=True)
+    old.mkdir(exist_ok=True)
+    new.mkdir(exist_ok=True)
+    (bad / "progress.json").write_text("{invalid-json")
+    (old / "progress.json").write_text(
+        '{"run_id":"stub_d_100","provider":"stub","dataset":"d","completed":[],"failed":[]}'
+    )
+    (new / "progress.json").write_text(
+        '{"run_id":"stub_d_200","provider":"stub","dataset":"d","completed":[],"failed":[]}'
+    )
+    old_ts = time.time() - 10
+    new_ts = time.time()
+    os_old = old / "progress.json"
+    os_new = new / "progress.json"
+    os_old.touch()
+    os_new.touch()
+    import os
+
+    os.utime(os_old, (old_ts, old_ts))
+    os.utime(os_new, (new_ts, new_ts))
+    cp = engine._find_latest_checkpoint("stub", "d")
+    assert cp is not None
+    assert cp.run_id == "stub_d_200"
+
+
+@pytest.mark.asyncio
+async def test_finalize_run_metrics_sink_and_history_error_suppressed(monkeypatch: pytest.MonkeyPatch) -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+    engine._metrics_enabled = True
+    engine._counters = {"rows_written_total": 0}
+    engine._hists = {}
+    engine._summary = {}
+    engine._completed_symbols = {"AAPL"}
+    engine._failed_symbols = {"MSFT"}
+    engine._checkpoint_lock = asyncio.Lock()
+
+    class _Sink:
+        @staticmethod
+        def summary(_payload: dict[str, float]) -> None:
+            raise RuntimeError("sink boom")
+
+    engine._metrics_sink = _Sink()
+    engine._config.persist_run_history = True
+
+    async def _noop_flush(*, suppress: bool, consume: bool = True) -> None:
+        return None
+
+    monkeypatch.setattr(engine, "_try_flush_once", _noop_flush, raising=True)
+    monkeypatch.setattr(engine, "_merge_component_counters", lambda: None, raising=True)
+    monkeypatch.setattr(engine, "_compute_summary", lambda: {"http_duration_s_p95": 1.0}, raising=True)
+    monkeypatch.setattr(engine, "_emit_pipeline_summary_log", lambda **kwargs: None, raising=True)
+    monkeypatch.setattr(engine, "_update_checkpoint", lambda *args, **kwargs: None, raising=True)
+    import vertex_forager.core.pipeline as pipeline_mod
+
+    def _save_run_history_fail(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("history boom")
+
+    monkeypatch.setattr(pipeline_mod, "save_run_history", _save_run_history_fail)
+    result = RunResult(provider="stub")
+    await engine._finalize_run(result=result, dataset="d", run_id="rid", started_monotonic=time.monotonic() - 1.0)
+    assert result.metrics_summary.get("http_duration_s_p95") == 1.0
+    assert result.finished_at is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_worker_handles_none_job_then_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+
+    class _Req:
+        @staticmethod
+        def task_done() -> None:
+            return None
+
+    req_q = _Req()
+    pkt_q: asyncio.Queue[FramePacket | None] = asyncio.Queue()
+    result = RunResult(provider="stub")
+    lock = asyncio.Lock()
+    order_counter = itertools.count()
+    steps = [
+        (0, None, [], False),
+        (engine.PRIORITY_SENTINEL, None, [], True),
+    ]
+
+    async def _dequeue_worker_job(**kwargs: object):
+        return steps.pop(0)
+
+    monkeypatch.setattr(engine, "_dequeue_worker_job", _dequeue_worker_job, raising=True)
+    monkeypatch.setattr(engine, "_drain_deferred_demotes", lambda **kwargs: None, raising=True)
+    monkeypatch.setattr(engine, "_requeue_demoted_jobs", lambda **kwargs: None, raising=True)
+
+    async def _process_worker_job(**kwargs: object):
+        return b"x", None, ParseResult(packets=[], next_jobs=[])
+
+    monkeypatch.setattr(engine, "_process_worker_job", _process_worker_job, raising=True)
+
+    async def _record_worker_symbol_state(**kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(engine, "_record_worker_symbol_state", _record_worker_symbol_state, raising=True)
+    sleep_calls = {"n": 0}
+
+    async def _sleep(_delay: float) -> None:
+        sleep_calls["n"] += 1
+
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+    await engine._fetch_worker(
+        0,
+        req_q=req_q,  # type: ignore[arg-type]
+        pkt_q=pkt_q,
+        result=result,
+        result_lock=lock,
+        order_counter=order_counter,
+        on_progress=None,
+    )
+    assert sleep_calls["n"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_worker_logs_every_100_jobs(monkeypatch: pytest.MonkeyPatch) -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+
+    class _Req:
+        @staticmethod
+        def task_done() -> None:
+            return None
+
+    req_q = _Req()
+    pkt_q: asyncio.Queue[FramePacket | None] = asyncio.Queue()
+    result = RunResult(provider="stub")
+    lock = asyncio.Lock()
+    order_counter = itertools.count()
+    jobs = [
+        (
+            engine.PRIORITY_NEW_JOB,
+            FetchJob(provider="stub", dataset="d", symbol=f"S{i}", spec=RequestSpec(url="https://x")),
+            [],
+            False,
+        )
+        for i in range(100)
+    ]
+    jobs.append((engine.PRIORITY_SENTINEL, None, [], True))
+
+    async def _dequeue_worker_job(**kwargs: object):
+        return jobs.pop(0)
+
+    monkeypatch.setattr(engine, "_dequeue_worker_job", _dequeue_worker_job, raising=True)
+    monkeypatch.setattr(engine, "_drain_deferred_demotes", lambda **kwargs: None, raising=True)
+    monkeypatch.setattr(engine, "_requeue_demoted_jobs", lambda **kwargs: None, raising=True)
+
+    async def _process_worker_job(**kwargs: object):
+        return b"x", None, ParseResult(packets=[], next_jobs=[])
+
+    monkeypatch.setattr(engine, "_process_worker_job", _process_worker_job, raising=True)
+
+    async def _record_worker_symbol_state(**kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(engine, "_record_worker_symbol_state", _record_worker_symbol_state, raising=True)
+    debug_msgs: list[str] = []
+    import vertex_forager.core.pipeline as pipeline_mod
+
+    monkeypatch.setattr(
+        pipeline_mod.logger,
+        "debug",
+        lambda msg, *args: debug_msgs.append(str(msg)),
+        raising=True,
+    )
+    await engine._fetch_worker(
+        0,
+        req_q=req_q,  # type: ignore[arg-type]
+        pkt_q=pkt_q,
+        result=result,
+        result_lock=lock,
+        order_counter=order_counter,
+        on_progress=None,
+    )
+    assert any("Processed %s jobs so far..." in m for m in debug_msgs)


### PR DESCRIPTION
## Summary
- What does this change do?
  - Simplifies the fairness scheduler API by requiring a single `FairnessState` input and returning a named `SchedulerResult` instead of a 6-tuple.
  - Adds missing scheduler edge-case tests for symbol-change reset, empty-queue-after-demotion, and in-place `FairnessState` mutation.
  - Adds targeted pipeline tests to increase `core/pipeline.py` individual coverage above the 80% target.
  - Clarifies fairness/demotion acknowledgment contract and scheduler behavior via improved tests and API structure.
- Why is it needed?
  - Removes ambiguous dual fairness inputs (`fairness_state` vs scalar seed args) at call sites.
  - Reduces unpacking mistakes and improves readability/maintainability with a named result object.
  - Addresses post-merge review findings and ensures confidence in fairness edge behavior and pipeline teardown/error paths.

## Linked Issue
- Closes #238

## Type of Change
- [ ] docs
- [x] fix
- [ ] feat
- [x] refactor
- [ ] perf
- [x] test
- [ ] ci/chore

## Changes
- User-visible:
  - No external API/CLI behavior change intended.
- Internal:
  - `pop_next_job_respecting_fairness` now accepts only `FairnessState`.
  - Replaced tuple return with `SchedulerResult` dataclass.
  - Updated pipeline fairness call site to consume `SchedulerResult`.
  - Added scheduler tests for:
    - symbol-change burst reset
    - QueueEmpty-after-demotion path
    - in-place fairness state mutation
  - Added pipeline-targeted tests for uncovered branches (checkpoint selection, finalize error suppression, worker coordination branches, periodic debug path).
  - Preserved fairness algorithm semantics while tightening contracts.

## Verification
- Commands run:
  - `uv run ruff check packages/ --fix`
  - `uv run mypy packages/vertex-forager/src --strict`
  - `uv run pytest packages/ --cov-fail-under=80`
  - `uv run python scripts/check_cycles.py`
- Results:
  - All commands pass.
  - Tests: `372 passed, 1 skipped`
  - `core/pipeline.py` coverage: **82%** (target ≥ 80%)
  - No import cycles detected.

## Security Considerations
- No secrets/PII introduced.
- No dependency additions or permission model changes.
- Changes are limited to scheduler/pipeline internals and tests.

## Risk & Rollback
- Risk level: Medium (core scheduling and pipeline internals touched).
- Rollback:
  - Revert commit `eae694c` (or revert PR merge commit).
  - Re-run verification commands listed above.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Coverage excerpt:
  - `packages/vertex-forager/src/vertex_forager/core/pipeline.py ... 82%`
- Test summary:
  - `372 passed, 1 skipped`

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 스케줄러의 공정성 상태 처리 개선으로 더욱 안정적인 작업 처리 보장

* **Tests**
  * 체크포인트 복구, 작업 완료 처리, 워커 대기열 관리 등 주요 기능에 대한 테스트 커버리지 확대
  * 엣지 케이스 및 동시성 시나리오에 대한 추가 검증

<!-- end of auto-generated comment: release notes by coderabbit.ai -->