### PR TITLE
chore(ci): add workflow_run-based PR coverage comments and README badge (#226)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,14 @@ jobs:
             --cov-report=term \
             --cov-fail-under=80 \
             -m "not manual"
+      - name: Upload coverage data
+        if: ${{ matrix.python-version == '3.10' }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808  # v4 pinned
+        with:
+          name: coverage-data
+          path: .coverage
+          include-hidden-files: true
+          if-no-files-found: error
       - name: Run Tests (manual only)
         if: ${{ matrix.python-version == '3.10' && github.event_name == 'workflow_dispatch' && github.event.inputs.include_manual == 'true' }}
         run: |

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,54 @@
+---
+name: Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Vertex CI"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post PR coverage diff comment
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      pull-requests: write
+      contents: read
+      actions: read
+    steps:
+      - name: Download coverage data artifact
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9 pinned
+        with:
+          name: coverage-data
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: .
+      - name: Publish PR coverage comment
+        uses: py-cov-action/python-coverage-comment-action@7188638f871f721a365d644f505d1ff3df20d683  # v3.40 pinned
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+
+  coverage-badge:
+    name: Update coverage badge data
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' && github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5 pinned
+        with:
+          persist-credentials: true
+      - name: Download coverage data artifact
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806  # v4.1.9 pinned
+        with:
+          name: coverage-data
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: .
+      - name: Update coverage badge/dashboard data
+        uses: py-cov-action/python-coverage-comment-action@7188638f871f721a365d644f505d1ff3df20d683  # v3.40 pinned
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Vertex Lab - Data Science Platform
 
 [![Docs](https://img.shields.io/badge/docs-online-blue)](https://coolbress.github.io/VertexLab/)
+[![Coverage](https://raw.githubusercontent.com/coolbress/VertexLab/python-coverage-comment-action-data/badge.svg)](https://github.com/coolbress/VertexLab/tree/python-coverage-comment-action-data)
 
 Modern Python monorepo for financial data collection, analysis, and visualization.
 


### PR DESCRIPTION
## Summary
- What does this change do?
  - Uploads `.coverage` as an artifact from CI.
  - Adds a new `coverage-comment.yml` workflow triggered by `workflow_run` from `Vertex CI`.
  - Posts per-PR coverage diff comments (including new/changed line coverage context) using `python-coverage-comment-action`.
  - Updates coverage badge data on successful `main` pushes.
  - Adds a coverage badge to `README.md`.
- Why is it needed?
  - Lets reviewers see coverage impact directly in PR discussions without leaving GitHub review flow.
  - Avoids external services (e.g., Codecov) and relies only on `GITHUB_TOKEN`.
  - Keeps security posture strong for fork PRs by using a trusted `workflow_run` path.

## Linked Issue
- Closes #226

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [x] ci/chore

## Changes
- User-visible:
  - Added coverage badge to root README.
- Internal:
  - `.github/workflows/ci.yml`
    - Added artifact upload step for `.coverage` (`coverage-data`) after pytest coverage run.
  - `.github/workflows/coverage-comment.yml` (new)
    - `workflow_run` trigger on `Vertex CI` completion.
    - PR path: posts coverage diff comments with `pull-requests: write`, `actions: read`, `contents: read`.
    - Main push path: updates coverage badge/dashboard data with `contents: write`.
  - `README.md`
    - Added badge linking to `python-coverage-comment-action-data` branch output.

## Verification
- Local project gates:
  - `uv run ruff check packages/ --fix`
  - `uv run mypy packages/vertex-forager/src --strict`
  - `uv run pytest packages/ --cov-fail-under=80`
  - `uv run python scripts/check_cycles.py`
- Workflow integrity:
  - `coverage-comment.yml` uses `workflow_run` and PR-job condition checks:
    - `github.event.workflow_run.event == 'pull_request'`
    - `github.event.workflow_run.conclusion == 'success'`
  - Existing `--cov-fail-under=80` gate remains unchanged in CI.

## Security Considerations
- No external coverage SaaS integration introduced.
- Uses only `GITHUB_TOKEN`.
- PR comment flow is isolated via `workflow_run`, avoiding unsafe execution context for fork PR write permissions.
- No secrets/PII introduced.

## Risk & Rollback
- Risk level: Low (additive CI/workflow changes).
- Failure mode:
  - If coverage-comment action fails, core CI quality gates still enforce test/coverage threshold.
- Rollback:
  - Remove `.github/workflows/coverage-comment.yml`.
  - Remove coverage artifact upload step from `ci.yml`.
  - Remove README coverage badge line.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Coverage gate remains enforced in CI:
  - `--cov-fail-under=80`
- Expected PR UX:
  - Coverage diff comment appears on successful PR CI run.

## Checklist
- [x] ruff/mypy/pytest pass locally
- [x] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 테스트 커버리지 데이터를 자동으로 수집하는 CI/CD 워크플로우를 추가했습니다.
  * 풀 리퀘스트에 커버리지 분석 피드백을 자동으로 제공하도록 구성했습니다.
  * 메인 브랜치의 커버리지 대시보드를 자동으로 업데이트하도록 설정했습니다.

* **Documentation**
  * 프로젝트 README에 커버리지 상태 배지를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->