### PR TITLE
docs: consolidate duplicated quality-gate checklist references (#237)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Thank you for contributing to Vertex Forager!
 - Run quality gates locally:
   - `uv run ruff check packages/`
   - `uv run mypy packages/vertex-forager/src --strict`
-  - `uv run pytest packages/ -q`
+  - `uv run pytest packages/ --cov-fail-under=80`
   - Note: pre-commit runs mypy against the same target (`packages/vertex-forager/src`) with `--strict` to ensure local and CI type errors match. Install hooks via `pre-commit install`.
   - Note (tests): keep packages/vertex-forager/tests/** exceptions S101 and TC002/TC003/TC006 for pytest assert ergonomics and type-checking imports.
   - See `packages/vertex-forager/tests/README.md` for test structure (unit/integration/property/verification) and markers (`smoke`, `manual`), plus commands and CI policy.
@@ -34,10 +34,8 @@ Thank you for contributing to Vertex Forager!
 ## Tests
 
 - Test layout, markers, and CI policy are documented in `packages/vertex-forager/tests/README.md`.
-- Quick commands:
-  - Default fast suite: `pytest packages/ -m "not manual"`
-  - Manual tests only: `pytest packages/ -m manual`
-  - Coverage gate: `pytest packages/ --cov --cov-fail-under=80`
+- For the canonical quality-gate checklist, use **Development quickstart → Run quality gates locally**.
+- Test-selection commands (non-gate) are documented in `packages/vertex-forager/tests/README.md`.
 
 ## Benchmark baseline policy
 

--- a/packages/vertex-forager/docs/how-to/dlq-disabled.md
+++ b/packages/vertex-forager/docs/how-to/dlq-disabled.md
@@ -26,7 +26,7 @@ client = create_client(
 )
 ```
 
-2) Run your fetch:
+1) Run your fetch:
 
 ```python
 res = client.get_price_data(tickers=["AAPL"], connect_db="duckdb://./forager.duckdb")

--- a/packages/vertex-forager/tests/README.md
+++ b/packages/vertex-forager/tests/README.md
@@ -14,8 +14,7 @@
 ## Local Commands
 - Fast suite (default): `pytest packages/ -m "not manual"`
 - Manual only: `pytest packages/ -m manual`
-- Coverage: `pytest packages/ --cov --cov-fail-under=80`
-- Lint & typecheck: `ruff check packages/ --fix && mypy packages/vertex-forager/src --strict`
+- For quality gates (coverage/lint/typecheck), use the canonical checklist in [CONTRIBUTING.md](../../../CONTRIBUTING.md#development-quickstart).
 
 ## CI Policy
 - Default run excludes manual tests for speed and determinism.


### PR DESCRIPTION
## Summary
- What does this change do?
  - Keeps one canonical quality-gate checklist in `CONTRIBUTING.md` (Development quickstart).
  - Replaces duplicated gate command blocks in other docs with references to the canonical section.
  - Applies a small markdown numbering cleanup in `dlq-disabled.md` to satisfy lint rules.
- Why is it needed?
  - Duplicate command lists increase maintenance overhead and can drift over time.
  - A single source of truth makes future command updates safer and simpler.

## Linked Issue
- Closes #237

## Type of Change
- [x] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [ ] ci/chore

## Changes
- User-visible:
  - Documentation now points to one canonical quality-gate checklist location.
- Internal:
  - `CONTRIBUTING.md`
    - Keeps/clarifies canonical quality-gate checklist under Development quickstart.
    - Removes duplicate gate command listing from the Tests section and replaces it with a pointer.
  - `packages/vertex-forager/tests/README.md`
    - Replaces duplicated coverage/lint/typecheck commands with a reference to `CONTRIBUTING.md`.
  - `packages/vertex-forager/docs/how-to/dlq-disabled.md`
    - Fixes ordered-list numbering (`2)` → `1)`) for markdownlint compliance.

## Verification
- `uvx pre-commit run lychee --hook-stage manual --all-files` ✅
- `uvx pre-commit run markdownlint-cli2 --all-files` ✅
- `uv run ruff check packages/ --fix` ✅
- `uv run mypy packages/vertex-forager/src --strict` ✅

## Security Considerations
- No secrets/PII changes.
- No dependency or permission changes.
- Documentation-only scope.

## Risk & Rollback
- Risk level: Low.
- Rollback:
  - Revert this docs commit to restore previous command listings.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- N/A (docs-only change).

## Checklist
- [x] ruff/mypy/pytest pass locally
- [x] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 개발자 가이드의 품질 게이트 테스트 명령어를 업데이트했습니다.
  * 공식 품질 게이트 체크리스트의 중앙 집중식 위치를 명확히 했습니다.
  * 테스트 선택 명령어와 관련 문서의 참조 위치를 정리했습니다.
  * 튜토리얼 단계 번호를 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->