### PR TITLE
chore(ci): add label-based GitHub release note categories (#236)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,7 +5,7 @@ changelog:
   categories:
     - title: Breaking Changes
       labels:
-        - impact:user
+        - type:breaking
     - title: New Features
       labels:
         - type:feature

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -59,6 +59,7 @@ jobs:
             "type:docs|0075ca|Documentation changes",
             "type:chore|d4c5f9|Chores and maintenance",
             "type:refactor|cfd3d7|Refactoring without behavior change",
+            "type:breaking|b60205|Backward-incompatible or breaking change",
             "type:perf|a2eeef|Performance improvements",
             "type:test|5319e7|Test related changes",
             "scope:writer|8ed1fc|Writers and sinks",


### PR DESCRIPTION
## Summary
- What does this change do?
  - Adds `.github/release.yml` to configure GitHub Release note categorization by PR labels.
  - Defines category mapping for Breaking Changes, New Features, Bug Fixes, Performance, Maintenance, and Documentation.
  - Excludes PRs labeled `skip-changelog` from generated release notes.
- Why is it needed?
  - Release notes were previously uncategorized, making release pages harder to scan.
  - Label-based grouping improves readability and makes major changes easier to discover.

## Linked Issue
- Closes #236

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [x] ci/chore

## Changes
- User-visible:
  - GitHub Release pages will now show grouped sections instead of flat PR lists.
  - Unmatched PRs remain under GitHub’s default “Other Changes” section.
- Internal:
  - Added `.github/release.yml` with:
    - `exclude.labels: [skip-changelog]`
    - category-to-label mappings:
      - Breaking Changes → `type:breaking`
      - New Features → `type:feat`
      - Bug Fixes → `type:fix`
      - Performance → `type:perf`
      - Maintenance → `type:chore`, `type:refactor`, `type:ci`
      - Documentation → `type:docs`, `documentation`

## Verification
- YAML validity:
  - `uv run python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/release.yml').read_text()); print('release.yml OK')"` ✅
- Baseline checks:
  - `actionlint` ✅
  - `uv run ruff check packages/ --fix` ✅
  - `uv run mypy packages/vertex-forager/src --strict` ✅
- Functional behavior expectation:
  - On next GitHub Release creation, PRs are grouped by configured label categories.

## Security Considerations
- No secrets/PII changes.
- No permission changes.
- No dependency/runtime behavior changes; UI-only release note formatting impact.

## Risk & Rollback
- Risk level: Low.
- Rollback:
  - Remove `.github/release.yml` (or revert this commit) to return to default GitHub release-note behavior.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Optional screenshot:
  - Next created GitHub Release page showing categorized PR sections.

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 릴리스 노트/변경 로그 자동 생성 구성 추가: `no-changelog` 태그 항목 제외 및 변경사항을 주요 카테고리(주요 변경·새 기능·버그 수정·성능·유지보수·문서)로 정리합니다.
  * 라벨 동기화에 `type:breaking`(후방호환성 없는 변경) 라벨 추가로 릴리스 카테고리 분류 범위 확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->