### PR TITLE
chore: add editorconfig and shared vscode settings (#165)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitignore
+++ b/.gitignore
@@ -11,11 +11,12 @@ env/
 .mypy_cache/
 
 # IDE
-.vscode/
 .idea/
 *.swp
 *.swo
 .trae/
+.vscode/launch.json
+.vscode/tasks.json
 
 # OS
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "ms-python.mypy-type-checker",
+    "ms-python.python"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "charliermarsh.ruff",
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff"
+  },
+  "mypy-type-checker.args": [
+    "--strict"
+  ],
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "packages/"
+  ]
+}


### PR DESCRIPTION
## Summary
- What does this change do?
  - Adds `.editorconfig` at the repository root to standardize indentation, line endings, charset, and final newline behavior across editors.
  - Adds shared VS Code workspace files:
    - `.vscode/extensions.json` with recommended project tooling extensions
    - `.vscode/settings.json` with Ruff formatter, strict mypy args, and pytest runner defaults
  - Updates `.gitignore` so `.vscode/` is no longer globally ignored, while personal local files remain excluded (`.vscode/launch.json`, `.vscode/tasks.json`).
- Why is it needed?
  - Removes editor-specific formatting drift and gives new contributors a consistent out-of-the-box local setup.
  - Aligns repository developer experience with common modern Python project practices.

## Linked Issue
- Closes #165

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [x] ci/chore

## Changes
- User-visible:
  - Contributors using VS Code get formatter/test/type-check defaults automatically from workspace settings.
  - Formatting behavior is standardized across IDE/editor choices via `.editorconfig`.
- Internal:
  - Added `.editorconfig`
  - Added `.vscode/extensions.json`
  - Added `.vscode/settings.json`
  - Updated `.gitignore` to allow committing shared `.vscode` settings while keeping personal files excluded

## Verification
- File existence checks:
  - `test -f .editorconfig`
  - `test -f .vscode/extensions.json`
  - `test -f .vscode/settings.json`
- Ignore policy check:
  - Confirmed `.vscode/` is not ignored globally in `.gitignore`
- Quality checks:
  - `uv run ruff check packages/ --fix`
  - `uv run mypy packages/vertex-forager/src --strict`

## Security Considerations
- No secrets/credentials added.
- No dependency or permission model changes.
- Configuration-only change.

## Risk & Rollback
- Risk level: Low.
- Rollback:
  - Revert this commit (or remove the three config files and `.gitignore` updates).

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Optional: VS Code workspace settings preview showing Ruff formatter and pytest/mypy defaults.

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 기타

* **개발 환경 구성** 업데이트: 편집기 설정 및 코드 포맷팅 도구 구성을 표준화했습니다.
* **권장 개발 도구** 추가: 개발 환경 최적화를 위한 필수 도구 설정을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->