### PR TITLE
chore(ci): migrate dependency automation baseline to Renovate (#231)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "main"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0
     rebase-strategy: "auto"
     commit-message:
       prefix: "ci"
@@ -20,13 +20,3 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "aquasecurity/trivy-action"
         update-types: ["version-update:semver-major"]
-  - package-ecosystem: "pip"
-    directory: "/packages/vertex-forager"
-    schedule:
-      interval: "weekly"
-    target-branch: "main"
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: "deps"
-    labels:
-      - "dependencies"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>astral-sh/renovate-config"
+  ],
+  "schedule": [
+    "before 9am on Monday"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "uv"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- What does this change do?
  - Introduces Renovate configuration at `.github/renovate.json`, based on `astral-sh/renovate-config`.
  - Enables patch-level automerge for `uv`-managed updates (PR automerge after checks pass).
  - Enables digest pinning behavior for GitHub Actions updates in Renovate.
  - Removes duplicate update source by deleting Dependabot `pip` updates and disabling Dependabot GitHub Actions PR creation (`open-pull-requests-limit: 0`).
- Why is it needed?
  - Prevents duplicate PR noise from running Dependabot and Renovate on overlapping ecosystems.
  - Improves dependency update quality (grouping/pinning/automerge flexibility) for monorepo workflows.

## Linked Issue
- Closes #231

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [ ] test
- [x] ci/chore

## Changes
- User-visible:
  - Dependency update PR behavior will be driven by Renovate once the app is installed and onboarding is merged.
- Internal:
  - Added `.github/renovate.json`:
    - `"$schema": "https://docs.renovatebot.com/renovate-schema.json"`
    - `extends: ["github>astral-sh/renovate-config"]`
    - `schedule: ["before 9am on Monday"]`
    - package rule: `uv` + `patch` → `automerge: true`, `automergeType: "pr"`
    - package rule: `github-actions` → `pinDigests: true`
  - Updated `.github/dependabot.yml`:
    - Removed `pip` ecosystem block for `/packages/vertex-forager`
    - Set GitHub Actions block `open-pull-requests-limit: 0` to avoid overlap with Renovate

## Verification
- Config syntax:
  - `python -m json.tool .github/renovate.json` ✅
- CI/local static checks:
  - `actionlint` ✅
  - `uv run ruff check packages/ --fix` ✅
  - `uv run mypy packages/vertex-forager/src --strict` ✅
- Expected post-merge operational validation:
  - Renovate app installed and active
  - Onboarding PR appears and is merged
  - Patch update PRs auto-merge after required checks
  - No duplicate PRs from Dependabot + Renovate for same ecosystem

## Security Considerations
- No credentials or secrets added.
- No runtime application behavior changes.
- Dependency automation policy/config only.

## Risk & Rollback
- Risk level: Medium (depends on external GitHub App installation and policy behavior).
- Rollback:
  - Re-enable Dependabot blocks in `.github/dependabot.yml`
  - Remove `.github/renovate.json`
  - Uninstall/disable Renovate app if needed

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Optional:
  - Renovate onboarding PR screenshot
  - First grouped dependency PR with automerge metadata

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 의존성 관리 자동화 설정을 업데이트했습니다.
  * GitHub Actions 업데이트 정책을 조정했습니다.
  * 새로운 자동화 구성 파일을 추가하여 정기적인 의존성 관리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->