### PR TITLE
test: mock yfinance I/O to stabilize non-blocking benchmark checks (#272)

### DIFF
--- a/packages/vertex-forager/tests/verification/verify_pipeline_perf.py
+++ b/packages/vertex-forager/tests/verification/verify_pipeline_perf.py
@@ -2,6 +2,7 @@ import json
 import math
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from vertex_forager.utils import as_dict
@@ -61,7 +62,9 @@ def _run_mocked_price_collection(
         ticker = kwargs.get("tickers")
         if isinstance(ticker, str) and ticker in fixture_map:
             return fixture_map[ticker].copy()
-        return _build_fixture_frame("AAPL")
+        if isinstance(ticker, str):
+            raise ValueError(f"Unexpected ticker requested in mocked yfinance.download: {ticker}")
+        raise ValueError("Mocked yfinance.download expected keyword argument `tickers` as a string symbol.")
 
     class _MockTicker:
         def __init__(self, symbol: str) -> None:
@@ -70,11 +73,11 @@ def _run_mocked_price_collection(
         def history(self, **_: object) -> object:
             if self._symbol in fixture_map:
                 return fixture_map[self._symbol].copy()
-            return _build_fixture_frame("AAPL")
+            raise ValueError(f"Unexpected ticker requested in mocked yfinance.Ticker.history: {self._symbol}")
 
-    with (
-        patch("vertex_forager.providers.yfinance.fetcher._http_mod.yf.download", side_effect=_mock_download),
-        patch("vertex_forager.providers.yfinance.fetcher._http_mod.yf.Ticker", side_effect=_MockTicker),
+    with patch(
+        "vertex_forager.providers.yfinance.fetcher._http_mod.yf",
+        new=SimpleNamespace(download=_mock_download, Ticker=_MockTicker),
     ):
         if warmup_db_path.exists():
             warmup_db_path.unlink()


### PR DESCRIPTION
## Summary
- What does this change do?
  - Rewrites `packages/vertex-forager/tests/verification/verify_pipeline_perf.py` so benchmark execution no longer depends on real yfinance network I/O.
  - Uses deterministic fixture data for the same 5 ticker workload (`AAPL`, `MSFT`, `NVDA`, `GOOGL`, `AMZN`) and runs the full pipeline path (fetch → parse → write → metrics).
  - Keeps `duration_s` as the benchmark metric and preserves CI threshold usage (`BENCHMARK_MAX_REGRESSION=0.20`).
- Why is it needed?
  - Main-branch benchmark regressions were repeatedly false positives due to shared-runner network variance, not real compute regressions.
  - Removing network from measurement makes benchmark output stable and regression signal meaningful.

## Linked Issue
- Closes #272

## Type of Change
- [ ] docs
- [ ] fix
- [ ] feat
- [ ] refactor
- [ ] perf
- [x] test
- [ ] ci/chore

## Changes
- User-visible:
  - No product behavior changes.
- Internal:
  - Added fixture-frame generation for benchmark input data.
  - Mocked both yfinance call paths used by provider flow:
    - `yf.download(...)`
    - `yf.Ticker(symbol).history(...)`
  - Kept benchmark metric contract (`duration_s`) intact.
  - Added safer duration handling:
    - prefer `run.duration_s` when valid
    - fallback to `finished_at - started_at`
    - raise explicit error if duration is invalid
  - Added warm-up run before the measured run to reduce cold-start noise while keeping a single measured output.

## Verification
- Local quality gates:
  - `actionlint` ✅
  - `uv run ruff check packages/ --fix` ✅
  - `uv run mypy packages/vertex-forager/src --strict` ✅
- Benchmark script validation:
  - `uv run python packages/vertex-forager/tests/verification/verify_pipeline_perf.py` ✅
  - Repeated 3-run check confirms stable variance below threshold target:
    - sample durations around `0.045s ~ 0.047s`
    - variance about `4.84%` (< `20%`) ✅

## Security Considerations
- No secrets/PII changes.
- No new permissions.
- Test-only logic change; production runtime paths unchanged.

## Risk & Rollback
- Risk level: Low.
- Scope limited to benchmark verification script.
- Rollback:
  - Revert `verify_pipeline_perf.py` to previous revision.

## Breaking Change?
- [ ] Yes (backward-incompatible)
- [x] No

## Screenshots / CLI Output (optional)
- Optional CLI evidence:
  - script writes `profile_metrics.json`
  - repeated runs show low variance with mocked I/O

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 성능 검증 파이프라인의 테스트 안정성이 개선되었습니다. 합성 가격 데이터 생성과 벤치마크 지속시간 결정 로직이 추가되어 일관된 입력으로 신뢰할 수 있는 성능 측정이 가능합니다.
  * 외부 데이터 수집을 모의(mock)해 예측 가능한 워밍업 및 본측정 흐름을 지원합니다.

* **Chores**
  * 워밍업 데이터 정리 및 실패 시 더 명확한 예외 처리로 실행 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->