### PR TITLE
fix(vertex-lab): restore issue forms by removing empty title fields 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Report a bug to help us improve
-title: ""
 labels:
   - bug
   - type:fix

--- a/.github/ISSUE_TEMPLATE/docs_improvement.yml
+++ b/.github/ISSUE_TEMPLATE/docs_improvement.yml
@@ -1,6 +1,5 @@
 name: Docs improvement
 description: Suggest a documentation improvement
-title: ""
 labels:
   - type:docs
 body:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: Feature request
 description: Suggest an idea for this project
-title: ""
 labels:
   - type:feature
 body:

--- a/.github/ISSUE_TEMPLATE/tech_task.yml
+++ b/.github/ISSUE_TEMPLATE/tech_task.yml
@@ -1,6 +1,5 @@
 name: "Maintenance / CI / Chore"
 description: "Maintenance, CI, refactor, tests and other non-feature work"
-title: ""
 labels: ["type:chore"]
 assignees: []
 body:


### PR DESCRIPTION
## Summary
- Restores visibility of all custom issue forms in GitHub’s issue template picker.
- Fixes a regression introduced when all issue forms were changed to `title: ""`.
- Uses the valid approach for issue forms: omit `title` entirely to keep the title input empty by default.

## Linked Issue
- Closes #278

## Changes
- Removed `title: ""` from all issue form templates:
  - `.github/ISSUE_TEMPLATE/bug_report.yml`
  - `.github/ISSUE_TEMPLATE/feature_request.yml`
  - `.github/ISSUE_TEMPLATE/docs_improvement.yml`
  - `.github/ISSUE_TEMPLATE/tech_task.yml`
- No other issue-form fields were changed.
- Label defaults and form body fields remain intact.

## Verification
- Ran repository quality checks:
  - `actionlint`
  - `uv run ruff check packages/ --fix`
  - `uv run mypy packages/vertex-forager/src --strict`
- Confirmed only the four issue template files were modified.
- Expected post-merge behavior on default branch:
  - `Issues → New issue` shows:
    - Bug report
    - Feature request
    - Docs improvement
    - Maintenance / CI / Chore

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [x] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub 이슈 템플릿 구성을 정리했습니다. 버그 리포트, 문서 개선, 기능 요청, 기술 작업 템플릿에서 불필요한 필드를 제거하여 템플릿 관리를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->