### PR TITLE
fix(vertex-lab): restore PR automation label permissions

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -9,7 +9,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 jobs:


### PR DESCRIPTION
## Summary
- Restores automatic PR labeling in `pr-automation.yml`.
- Fixes a regression where label API calls failed with `403 Resource not accessible by integration`.
- Root cause was insufficient workflow permission under `pull_request_target`.

## Linked Issue
- Closes #281

## Changes
- Updated workflow permissions in `.github/workflows/pr-automation.yml`:
  - `pull-requests: read` → `pull-requests: write`
- Kept existing `issues: write` for label operations.
- No changes to labeling logic (`type:*`/`package:*` mapping), only permission scope correction.

## Verification
- Local checks passed:
  - `actionlint`
  - `uv run ruff check packages/ --fix`
  - `uv run mypy packages/vertex-forager/src --strict`
- Functional expectation after merge:
  - Opening/editing a PR triggers `PR Automation`
  - `type:*` and `package:*` labels are applied successfully (no 403 in logs)

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [x] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 내부 자동화 워크플로우 권한 구성을 업데이트했습니다.

**사용자에게 영향 없음**: 이 변경은 개발 인프라 개선으로, 사용 가능한 기능이나 동작에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->