### PR TITLE
fix(vertex-lab): raise benchmark regression threshold to 30% for shared runner variance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,7 +275,7 @@ jobs:
         env:
           VF_PROFILE_OUTPUT_DIR: ${{ github.workspace }}/output/forager-profiles
           BENCHMARK_METRIC_PATH: duration_s
-          BENCHMARK_MAX_REGRESSION: "0.20"
+          BENCHMARK_MAX_REGRESSION: "0.30"
         run: uv run python .github/scripts/compare_benchmark_metrics.py
       - name: Upload benchmark metrics artifact
         if: ${{ always() }}


### PR DESCRIPTION
## Summary
- Raises the benchmark regression threshold in CI from 20% to 30%.
- Reduces false-positive benchmark regression failures caused by shared GitHub Actions runner variance.
- Keeps the existing non-blocking benchmark job behavior while making CI output less noisy.

## Linked Issue
- Closes #300

## Changes
- Updated `.github/workflows/ci.yml`:
  - `BENCHMARK_MAX_REGRESSION: "0.20"` → `BENCHMARK_MAX_REGRESSION: "0.30"`
- No benchmark logic or metric collection behavior was changed in this PR.
- No blocking quality-gate behavior was changed; the benchmark job remains non-blocking.

## Verification
- `actionlint`
- `uv run ruff check packages/ --fix`
- `uv run mypy packages/vertex-forager/src --strict`
- Confirmed the benchmark comparison step in `ci.yml` now uses `0.30` as the maximum allowed regression threshold.

## Checklist
- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user‑visible)
- [x] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI 워크플로우의 벤치마크 비교 단계에서 허용 가능한 성능 저하 임계값을 조정했습니다.

**참고:** 이번 변경사항은 내부 인프라 업데이트이며 사용자에게 직접적인 영향을 미치지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->