### PR TITLE
docs(vertex-lab): fix vertex-forager installation link in root docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -41,7 +41,7 @@ Prefer a release tag such as `vertex-forager-v0.11.4` or a commit SHA for reprod
 
 Use package-specific docs when you want a direct workflow for an individual component:
 
-- `vertex-forager`: [installation docs](https://coolbress.github.io/VertexLab/vertex-forager/get-started/installation/)
+- `vertex-forager`: [installation docs](https://coolbress.github.io/VertexLab/vertex-forager/installation/)
 - `vertex-qt`: docs will be added when the package implementation is ready
 
 - `vertex-forager` handles data collection, schema-aware normalization, and DuckDB persistence
@@ -53,7 +53,7 @@ Use package-specific docs when you want a direct workflow for an individual comp
 | Use case | Recommended install |
 | --- | --- |
 | You want the top-level VertexLab package and the root project docs experience | Clone the repo and run `uv sync --group dev` |
-| You want the current production-ready data ingestion workflow right now | Install `vertex-forager` from GitHub and follow the [vertex-forager installation docs](https://coolbress.github.io/VertexLab/vertex-forager/get-started/installation/) |
+| You want the current production-ready data ingestion workflow right now | Install `vertex-forager` from GitHub and follow the [vertex-forager installation docs](https://coolbress.github.io/VertexLab/vertex-forager/installation/) |
 | You need the yfinance-backed provider path | Install `vertex-forager[yfinance]` from GitHub |
 | You want notebook execution support for examples and experiments | Install `vertex-forager[notebook]` from GitHub |
 | You are waiting for future quant-analysis package guidance | `vertex-qt` docs will be added when the package is ready |


### PR DESCRIPTION
## Summary
- Fixes a broken root-docs link to the `vertex-forager` installation page.
- Updates the root `vertex-lab` installation guide to point at the current published `vertex-forager` docs path.
- Resolves the docs-deploy link-check failure caused by the stale `get-started/installation/` URL.

## Linked Issue
- Follow-up to #312
- Fixes docs-deploy failure on `fd8a902`

## Changes
- Updated [docs/installation.md](file:///Users/coolbress/vertex-lab/docs/installation.md) to replace:
  - `https://coolbress.github.io/VertexLab/vertex-forager/get-started/installation/`
  - with
  - `https://coolbress.github.io/VertexLab/vertex-forager/installation/`
- Fixed both references in the root installation guide:
  - component docs link section
  - install-path recommendation table

## Root Cause
- The `vertex-forager` docs IA was changed so installation moved from `get-started/installation.md` to top-level `installation.md`.
- Root `vertex-lab` docs still referenced the old published URL.
- The docs-deploy `lychee` check correctly flagged the stale URL as a 404.

## Verification
- Confirmed the new docs URL resolves:
  - `https://coolbress.github.io/VertexLab/vertex-forager/installation/`
- `actionlint`
- `uv run ruff check packages/ --fix`
- `uv run mypy packages/vertex-forager/src --strict`
- `NO_MKDOCS_2_WARNING=1 uv run --with mkdocs --with mkdocs-material --with mkdocs-monorepo-plugin --with 'mkdocstrings[python]' --with pymdown-extensions mkdocs build --strict`

## Checklist
- [x] Docs updated (if user-visible)
- [x] CI gates pass locally
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* **문서**
  * 설치 관련 문서의 참조 링크 경로 구조가 간소화되어 더욱 직관적이고 일관성 있는 형태로 개선되었습니다. 패키지별 설치 가이드 링크와 프로덕션 환경의 데이터 수집 워크플로우 섹션의 모든 참조 링크가 새로운 통합 경로로 변경되었습니다. 이를 통해 사용자는 필요한 설치 정보와 워크플로우 가이드에 더욱 신속하고 효율적으로 접근할 수 있게 되었습니다. 실제 설치 명령어와 문서 내용은 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->