### PR TITLE
docs(vertex-forager): rewrite landing page and quickstart for users

### DIFF
--- a/packages/vertex-forager/docs/index.md
+++ b/packages/vertex-forager/docs/index.md
@@ -5,22 +5,31 @@
 ![Python](https://img.shields.io/badge/Python-3.10%2B-blue)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/coolbress/VertexLab/blob/main/LICENSE)
 
-Provider-agnostic financial data ingestion with resilient writes, schema-aware normalization, and operational controls for production-oriented pipelines.
+Fetch financial data from multiple providers and build your own local database — no cloud required, no infrastructure to manage.
+
+Built-in providers today: yfinance and Sharadar.
 
 ## Why vertex-forager
 
-- Fetch data through a unified client layer across HTTP and library-backed providers
-- Normalize frames with Polars and schema-aware validation before persistence
-- Persist safely with DuckDB and DLQ-backed recovery controls
-- Inspect configuration, metrics, and API behavior through dedicated reference docs
+Getting financial data into a usable local database is harder than it should be. Rate limits kick in, writes fail halfway through, and large datasets take too long to re-fetch when something goes wrong.
+
+vertex-forager handles the operational complexity so you can focus on the data:
+
+- **Async bulk collection** — fetch large datasets concurrently within API rate limits so workflows that would be slow sequentially can finish much faster
+- **Multiple providers, one interface** — switch between yfinance and Sharadar without rewriting your collection flow
+- **Automatic rate limiting** — built-in throttling helps you stay within API limits without manual sleep logic
+- **Safe local persistence** — schema-aware normalization into DuckDB with idempotent upserts means reruns do not create duplicates
+- **Resilient writes** — failed packets can be recovered later instead of forcing a full re-fetch after a transient error
+- **Data quality checks** — built-in rules can catch duplicates, future dates, and negative prices before they reach your database
+- **No cloud dependency** — everything runs locally on your own machine
 
 ## Installation
 
 ```bash
-pip install "vertex-forager @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
+pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
 ```
 
-vertex-forager is currently distributed from GitHub rather than PyPI. See [Installation](installation.md) for install variants, extras, and repository-based workflows.
+vertex-forager is currently distributed from GitHub rather than PyPI. The example below uses the yfinance provider, so the install snippet includes the `yfinance` extra. See [Installation](installation.md) for other install variants, extras, and repository-based workflows.
 
 ## Quick Example
 
@@ -28,10 +37,7 @@ vertex-forager is currently distributed from GitHub rather than PyPI. See [Insta
 from vertex_forager import create_client
 
 client = create_client(provider="yfinance", rate_limit=60)
-result = client.get_price_data(
-    tickers=["AAPL", "MSFT"],
-    connect_db="duckdb://./forager.duckdb",
-)
+result = client.get_price_data(tickers=["AAPL", "MSFT"])
 print(result)
 ```
 

--- a/packages/vertex-forager/docs/tutorials/quickstart.md
+++ b/packages/vertex-forager/docs/tutorials/quickstart.md
@@ -1,89 +1,138 @@
 # Quickstart
 
-Follow this hands‑on tutorial to fetch data and persist it to DuckDB.
+Follow this tutorial from a minimal in-memory example to a local DuckDB-backed bulk collection workflow.
 
 ## Prerequisites
 
 - Python 3.10+
-- If you want to run the repository example scripts below, first clone the repo and change into it:
+- Install the package from GitHub:
 
 ```bash
-git clone https://github.com/coolbress/VertexLab.git
-cd VertexLab
-```
-
-- Install package from GitHub:
-
-```bash
-# Pin to a release tag for reproducibility
 pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
 ```
 
-- Optional extras:
+- Optional notebook extras:
 
 ```bash
 pip install "vertex-forager[notebook] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
 ```
 
-## Provider‑agnostic: Fetch and Persist (sync‑friendly)
+## 1. Create a client
+
+Start with the minimum client setup:
+
+- `provider` selects the built-in data source
+- `rate_limit` sets the requests-per-minute target you want the client to respect
+
+```python
+from vertex_forager import create_client
+
+client = create_client(provider="yfinance", rate_limit=60)
+```
+
+For Sharadar, pass an API key when creating the client:
+
+```python
+from vertex_forager import create_client
+
+client = create_client(
+    provider="sharadar",
+    api_key="YOUR_SHARADAR_API_KEY",
+    rate_limit=500,
+)
+```
+
+## 2. Fetch data into memory
+
+If you do not pass `connect_db`, the result stays in memory and you get a Polars DataFrame back immediately.
+
+```python
+from vertex_forager import create_client
+
+client = create_client(provider="yfinance", rate_limit=60)
+prices = client.get_price_data(tickers=["AAPL", "MSFT"])
+print(prices.head())
+```
+
+This is the right stopping point if you only need a DataFrame for analysis or ad hoc exploration.
+
+## 3. Persist to DuckDB
+
+Add `connect_db` when you want to build or update a local DuckDB database. In persistence mode the method returns a run summary instead of the in-memory DataFrame.
+
+```python
+from vertex_forager import create_client
+
+client = create_client(provider="yfinance", rate_limit=60)
+run = client.get_price_data(
+    tickers=["AAPL", "MSFT"],
+    connect_db="duckdb://./forager.duckdb",
+)
+print(run.tables)
+print(run.errors)
+```
+
+You can inspect the stored tables directly with DuckDB:
+
+```python
+import duckdb
+
+con = duckdb.connect("./forager.duckdb")
+print(con.execute("show tables").fetchall())
+print(con.execute("select * from yfinance_price limit 5").fetchdf())
+con.close()
+```
+
+## 4. Bulk collection
+
+Once the simple flow works, scale it up with environment variables and a larger ticker set. This is a useful pattern for your own local refresh scripts and for the repository examples.
 
 ```python
 import os
+
 from vertex_forager import create_client
 
 provider = os.getenv("VF_PROVIDER", "yfinance").strip()
+tickers = [t.strip() for t in os.getenv("VF_TICKERS", "AAPL,MSFT,GOOGL,AMZN").split(",")]
+db_path = os.getenv("VF_DUCKDB_PATH", "./forager.duckdb")
+
 kwargs = {}
 if provider == "sharadar":
     kwargs["api_key"] = os.environ["SHARADAR_API_KEY"]
-client = create_client(provider=provider, **kwargs)
-tickers = [t.strip() for t in (os.getenv("VF_TICKERS") or "AAPL,MSFT").split(",")]
+    kwargs["rate_limit"] = 500
+else:
+    kwargs["rate_limit"] = 60
 
-# Persist to DuckDB by providing connect_db; returns a RunResult summary
-db_path = os.getenv("VF_DUCKDB_PATH", "./forager.duckdb")
-res = client.get_price_data(
+client = create_client(provider=provider, **kwargs)
+run = client.get_price_data(
     tickers=tickers,
     connect_db=f"duckdb://{db_path}",
     show_progress=False,
 )
-print(res)  # RunResult
+print(run)
 ```
 
-## Run Examples (DuckDB persist)
-
-- Persist to DuckDB (provider‑agnostic)
+The same pattern works well with the repository examples:
 
 ```bash
-VF_PROVIDER=yfinance VF_TICKERS=AAPL,MSFT \
+git clone https://github.com/coolbress/VertexLab.git
+cd VertexLab
+VF_PROVIDER=yfinance VF_TICKERS=AAPL,MSFT,GOOGL,AMZN \
 VF_DUCKDB_PATH=./forager.duckdb \
 uv run python packages/vertex-forager/examples/advanced_duckdb_metrics.py
 ```
 
-- Sharadar (requires SHARADAR_API_KEY; DuckDB persist)
+Sharadar requires `SHARADAR_API_KEY` in the environment:
 
 ```bash
-export SHARADAR_API_KEY=...   # your key
+export SHARADAR_API_KEY=YOUR_KEY
 VF_PROVIDER=sharadar VF_TICKERS=AAPL,MSFT \
 VF_DUCKDB_PATH=./forager.duckdb \
 uv run python packages/vertex-forager/examples/advanced_duckdb_metrics.py
 ```
 
-## CLI Quick Commands
-
-- Status
-
-```bash
-uv run vertex-forager status
-```
-
-- Collect (Sharadar)
-
-```bash
-export SHARADAR_API_KEY=...
-uv run vertex-forager collect -s AAPL -s MSFT --source sharadar
-```
-
 ## Next Steps
 
 - Configure concurrency and retries: see [EngineConfig](../reference/config.md)
-- Operate without DLQ spooling: see [DLQ disabled](../how-to/dlq-disabled.md)
-- Tune chunked flush: see [Chunked flush tuning](../how-to/chunked-flush.md)
+- Tune local collection behavior: see [Performance tuning](../how-to/performance-tuning.md)
+- Tune write batch sizes: see [Chunked flush tuning](../how-to/chunked-flush.md)


### PR DESCRIPTION
## Summary
- Rewrites the `vertex-forager` landing page so it leads with user value instead of internal implementation details.
- Restructures the quickstart into a progressive tutorial from client creation to in-memory fetches, DuckDB persistence, and bulk collection.
- Aligns install and example snippets more closely with the current package surface and built-in provider workflow.

## Linked Issue
- Closes #314

## Changes
- Updated [index.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/index.md)
  - replaced the technical one-line description with a user-facing value proposition
  - rewrote `Why vertex-forager` to focus on user benefits such as async bulk collection, safe local persistence, resilient writes, and no-cloud local workflows
  - simplified the quick example to `create_client(...) + get_price_data(...)` without `connect_db`
  - clarified that current built-in providers are `yfinance` and `Sharadar`
  - changed the install snippet to include the `yfinance` extra so the quick example matches the actual dependency surface

- Updated [quickstart.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/tutorials/quickstart.md)
  - restructured the tutorial into four progressive steps:
    - create a client
    - fetch data into memory
    - persist to DuckDB
    - run bulk collection
  - made step 1 minimal and beginner-friendly
  - made step 2 stop at a simple in-memory DataFrame flow
  - made step 3 introduce `connect_db` and show how to inspect stored DuckDB tables
  - made step 4 show a realistic bulk-collection pattern with `VF_PROVIDER`, `VF_TICKERS`, and `VF_DUCKDB_PATH`
  - improved the persistence example so it shows `RunResult` fields users are more likely to inspect (`tables`, `errors`)

## Why
- The old landing page read more like an internal architecture summary than a user-facing OSS entrypoint.
- The old quickstart introduced provider switching, environment variables, and persistence too early for first-time users.
- The revised flow makes the docs easier to scan, easier to copy/paste, and more aligned with how users typically adopt the package:
  - first run something simple
  - then persist locally
  - then scale up into a repeatable local database workflow

## Verification
- `actionlint`
- `uv run ruff check packages/ --fix`
- `uv run mypy packages/vertex-forager/src --strict`
- `NO_MKDOCS_2_WARNING=1 uv run --with mkdocs --with mkdocs-material --with mkdocs-monorepo-plugin --with 'mkdocstrings[python]' --with pymdown-extensions mkdocs build --strict`

## Checklist
- [x] Docs updated (if user-visible)
- [x] CI/docs validation passes locally
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서**
  * 기본 설명서를 업데이트하여 vertex-forager를 클라우드 불필요한 로컬 솔루션으로 재정의
  * 비동기 대량 수집, 자동 속도 제한, DuckDB 지속성 등의 주요 기능 강조
  * 빠른 시작 가이드 확장으로 인메모리 데이터 가져오기부터 로컬 데이터베이스 지속성까지 단계별 지침 제공
  * 다중 공급자(yfinance, Sharadar) 사용 예시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->