### PR TITLE
ci: configure renovate for GitHub Actions grouping and disable pandas/ipython major updates 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -50,7 +50,7 @@
         "major"
       ],
       "enabled": false,
-      "description": "Disabled while minimum Python <3.11 is supported. Remove when vertex-forager baseline raises to >=3.11."
+      "description": "pandas 3.x and ipython 9.x require Python >=3.11. Remove this rule when vertex-forager min-Python raises to >=3.11."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Configure Renovate to group GitHub Actions updates into two groups: digests (pinned with `pinDigests`) and versions (major/minor/patch)
- Disable automatic major version updates for `pandas` and `ipython` to avoid unexpected breaking changes

## Linked Issue

- Closes #376

## Changes

- Add `prConcurrentLimit: 5` to prevent renovate from opening too many PRs simultaneously
- Group GitHub Actions digest updates (`matchUpdateTypes: ["digest"]`) under `github-actions-digests` with `pinDigests: true`
- Group GitHub Actions version updates (`matchUpdateTypes: ["major", "minor", "patch"]`) under `github-actions-versions`
- Disable major updates for `pandas` and `ipython` packages

## Verification

- Review `.github/renovate.json` diff to confirm group rules and package DisableConfig are correctly structured

## Checklist

- [ ] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [ ] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 의존성 자동업데이트 동시 처리 수를 5로 제한하여 PR 흐름과 검토 부담을 안정화
  * GitHub Actions 관련 업데이트를 별도 그룹으로 분리: 다이제스트(핀된 이미지) 업데이트와 주요/부수/패치 버전 업데이트를 각각 그룹화하여 리뷰 편의성 향상
  * 특정 라이브러리(pandas, ipython)의 주요 버전 자동업데이트 규칙을 비활성화하여 운영 안정성 강화 (설명 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->