### PR TITLE
chore: configure renovate with semantic commits and Python/pyenv suppression

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,9 @@
     "github>astral-sh/renovate-config"
   ],
   "prConcurrentLimit": 5,
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
   "schedule": [
     "before 9am on Monday"
   ],
@@ -19,15 +22,29 @@
       "automergeType": "pr"
     },
     {
+      "matchPackageNames": [
+        "uv-build",
+        "uv_build"
+      ],
+      "semanticCommitScope": "build"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true,
+      "semanticCommitScope": "ci"
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],
       "matchUpdateTypes": [
         "digest"
       ],
+      "semanticCommitScope": "ci",
       "groupName": "GitHub Actions digests",
-      "groupSlug": "github-actions-digests",
-      "pinDigests": true
+      "groupSlug": "github-actions-digests"
     },
     {
       "matchManagers": [
@@ -38,6 +55,7 @@
         "minor",
         "patch"
       ],
+      "semanticCommitScope": "ci",
       "groupName": "GitHub Actions versions",
       "groupSlug": "github-actions-versions"
     },
@@ -51,6 +69,19 @@
       ],
       "enabled": false,
       "description": "pandas 3.x and ipython 9.x require Python >=3.11. Remove this rule when vertex-forager min-Python raises to >=3.11."
+    },
+    {
+      "matchManagers": [
+        "pyenv"
+      ],
+      "matchFileNames": [
+        ".python-version"
+      ],
+      "matchPackageNames": [
+        "python"
+      ],
+      "enabled": false,
+      "description": "Python baseline changes are handled manually so they stay aligned with CI, docs, and conventional-commit workflow."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Enable Renovate semantic commits (`chore(deps): ...`) for all grouped dependency updates
- Assign semantic scopes per update category: `ci` for GitHub Actions, `build` for uv-build, `deps` for everything else
- Apply `pinDigests: true` at the GitHub Actions manager level so all actions (including newly added ones) get pinned digests
- Group GitHub Actions updates into digests and versions, each with their own semantic scope
- Suppress automatic Python version updates via pyenv (`.python-version`) since Python baseline changes must be handled manually to stay aligned with CI, docs, and conventional-commit workflow
- Retain pandas/ipython major update suppression from issue #376

## Linked Issue

- Closes #381

## Changes

- Add `semanticCommits: "enabled"` with `semanticCommitType: "chore"` and `semanticCommitScope: "deps"` as defaults
- Add top-level `pinDigests: true` + `semanticCommitScope: "ci"` for all GitHub Actions
- Split GitHub Actions into two groups: digests (`github-actions-digests`) and versions (`github-actions-versions`), both under `semanticCommitScope: "ci"`
- Add `semanticCommitScope: "build"` for `uv-build`/`uv_build` package updates
- Add pyenv suppression rule (`matchManagers: ["pyenv"]`) with description explaining manual Python baseline policy

## Verification

- Review `.github/renovate.json` diff to confirm semantic commit structure, `pinDigests` placement, and suppression rules are correctly configured

## Checklist

- [ ] CI gates pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [ ] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 의존성 관리 자동화 설정을 개선했습니다. 의존성 업데이트 커밋이 표준화된 메시지 규칙을 따르도록 설정했으며, 업데이트 유형에 따라 분류됩니다. Python 버전 변경 제안은 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->