### PR TITLE
fix(vertex-forager): update contributing link in testing.md to GitHub URL

### DIFF
--- a/packages/vertex-forager/docs/how-to/testing.md
+++ b/packages/vertex-forager/docs/how-to/testing.md
@@ -85,6 +85,6 @@ Use Hypothesis when testing functions that should satisfy invariants for any val
 
 ## Next Steps
 
-- Review contributor workflow: [Contributing](https://coolbress.github.io/VertexLab/contributing/)
+- Review contributor workflow: [Contributing](https://github.com/coolbress/VertexLab/blob/main/CONTRIBUTING.md)
 - Read the tutorial: [Quickstart](../tutorials/quickstart.md)
 - Check architecture details: [Pipeline architecture](../explanation/architecture.md)


### PR DESCRIPTION
## Summary

- **What does this change do?** Updates the Contributing link in `packages/vertex-forager/docs/how-to/testing.md` from the removed mkdocs internal URL to the GitHub blob URL.
- **Why is it needed?** After migrating `docs/contributing.md` to root-level `CONTRIBUTING.md`, the internal mkdocs `/contributing/` page no longer exists, causing 404 errors.

## Linked Issue

- N/A

## Changes

- `packages/vertex-forager/docs/how-to/testing.md`: Update Contributing link from `https://coolbress.github.io/VertexLab/contributing/` to `https://github.com/coolbress/VertexLab/blob/main/CONTRIBUTING.md`

## Verification

- [ ] CI passes
- [ ] Lychee link check passes

## Checklist

- [ ] CI passes
- [ ] Docs updated
- [ ] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * 기여자 워크플로우 관련 문서 링크를 GitHub 저장소의 CONTRIBUTING.md로 업데이트하여 더 직접적인 접근성을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->