### PR TITLE
feat(vertex-forager): async queue creation and thread-safe history save

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/lifecycle.py
+++ b/packages/vertex-forager/src/vertex_forager/core/lifecycle.py
@@ -47,7 +47,7 @@ def initialize_run_state(
     return run_id, completed_symbols, failed_symbols
 
 
-def create_run_queues(
+async def create_run_queues(
     *,
     queue_max: int,
     checkpoint_retention_days: int,
@@ -63,7 +63,8 @@ def create_run_queues(
     req_q: asyncio.PriorityQueue[tuple[int, int, Any | None]] = asyncio.PriorityQueue(maxsize=queue_max)
     pkt_q: asyncio.Queue[Any | None] = asyncio.Queue(maxsize=queue_max)
     try:
-        cleanup_state_retention(
+        await asyncio.to_thread(
+            cleanup_state_retention,
             checkpoint_retention_days=checkpoint_retention_days,
             run_history_retention_days=run_history_retention_days,
             dlq_retention_s=dlq_tmp_retention_s,
@@ -72,7 +73,7 @@ def create_run_queues(
         logger.warning("PIPELINE: State retention cleanup failed: %s", cleanup_error)
     if dlq_tmp_periodic_cleanup:
         try:
-            cleanup_dlq_tmp(cache_dir / "dlq", dlq_tmp_retention_s)
+            await asyncio.to_thread(cleanup_dlq_tmp, cache_dir / "dlq", dlq_tmp_retention_s)
         except Exception as cleanup_error:
             logger.warning("PIPELINE: DLQ periodic cleanup failed: %s", cleanup_error)
     return req_q, pkt_q

--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -648,7 +648,7 @@ class VertexForager:
 
         try:
             run_id, completed_symbols = self._initialize_run_state(dataset=dataset, resume=resume)
-            req_q, pkt_q = self._create_run_queues()
+            req_q, pkt_q = await self._create_run_queues()
             self._init_metrics_for_run()
             t_run0 = time.monotonic()
             result, result_lock = self._create_run_result(run_id=run_id, dataset=dataset)
@@ -932,13 +932,13 @@ class VertexForager:
                 self._merge_pending_jobs(latest_checkpoint.pending_jobs)
         return run_id, completed_symbols
 
-    def _create_run_queues(
+    async def _create_run_queues(
         self,
     ) -> tuple[
         asyncio.PriorityQueue[tuple[int, int, FetchJob | None]],
         asyncio.Queue[FramePacket | None],
     ]:
-        req_q, pkt_q = create_run_queues_impl(
+        req_q, pkt_q = await create_run_queues_impl(
             queue_max=self._config.queue_max,
             checkpoint_retention_days=self._config.checkpoint_retention_days,
             run_history_retention_days=self._config.run_history_retention_days,
@@ -1037,7 +1037,7 @@ class VertexForager:
                 "completed" if not self._failed_symbols and not self._pending_jobs else "in_progress",
             )
         try:
-            save_run_history(result, run_id)
+            await asyncio.to_thread(save_run_history, result, run_id)
             logger.debug("PIPELINE: Run history saved for run %s", run_id)
         except Exception as e:
             logger.warning("PIPELINE: Failed to save run history: %s", e)

--- a/packages/vertex-forager/tests/unit/test_core_lifecycle.py
+++ b/packages/vertex-forager/tests/unit/test_core_lifecycle.py
@@ -42,8 +42,9 @@ def test_initialize_run_state_with_checkpoint() -> None:
     assert failed == {"MSFT"}
 
 
-def test_create_run_queues_and_metrics_and_result() -> None:
-    req_q, pkt_q = create_run_queues(
+@pytest.mark.asyncio
+async def test_create_run_queues_and_metrics_and_result() -> None:
+    req_q, pkt_q = await create_run_queues(
         queue_max=10,
         checkpoint_retention_days=7,
         run_history_retention_days=90,
@@ -67,7 +68,8 @@ def test_create_run_queues_and_metrics_and_result() -> None:
     assert lock is not None
 
 
-def test_create_run_queues_passes_dlq_tmp_retention_s_to_cleanup(
+@pytest.mark.asyncio
+async def test_create_run_queues_passes_dlq_tmp_retention_s_to_cleanup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     captured: dict[str, int] = {}
@@ -82,7 +84,7 @@ def test_create_run_queues_passes_dlq_tmp_retention_s_to_cleanup(
     custom_checkpoint_retention = 14
     custom_run_history_retention = 180
     custom_dlq_retention = 3600
-    create_run_queues(
+    await create_run_queues(
         queue_max=10,
         checkpoint_retention_days=custom_checkpoint_retention,
         run_history_retention_days=custom_run_history_retention,
@@ -94,6 +96,43 @@ def test_create_run_queues_passes_dlq_tmp_retention_s_to_cleanup(
     assert captured.get("checkpoint_retention_days") == custom_checkpoint_retention
     assert captured.get("run_history_retention_days") == custom_run_history_retention
     assert captured.get("dlq_retention_s") == custom_dlq_retention
+
+
+@pytest.mark.asyncio
+async def test_create_run_queues_uses_to_thread_for_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def _fake_state_cleanup(
+        *,
+        checkpoint_retention_days: int,
+        run_history_retention_days: int,
+        dlq_retention_s: int,
+    ) -> None:
+        calls.append(f"state:{checkpoint_retention_days}:{run_history_retention_days}:{dlq_retention_s}")
+
+    def _fake_dlq_cleanup(base: Path, retention_s: int) -> None:
+        calls.append(f"dlq:{base.name}:{retention_s}")
+
+    async def _fake_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        calls.append(getattr(func, "__name__", "call"))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr("vertex_forager.core.lifecycle.cleanup_state_retention", _fake_state_cleanup)
+    monkeypatch.setattr("vertex_forager.core.lifecycle.cleanup_dlq_tmp", _fake_dlq_cleanup)
+    monkeypatch.setattr("vertex_forager.core.lifecycle.asyncio.to_thread", _fake_to_thread)
+
+    await create_run_queues(
+        queue_max=10,
+        checkpoint_retention_days=7,
+        run_history_retention_days=90,
+        dlq_tmp_periodic_cleanup=True,
+        dlq_tmp_retention_s=123,
+        cache_dir=Path("."),
+        logger=type("L", (), {"warning": lambda *args, **kwargs: None})(),
+    )
+
+    assert calls[:2] == ["_fake_state_cleanup", "state:7:90:123"]
+    assert calls[2:] == ["_fake_dlq_cleanup", "dlq:dlq:123"]
 
 
 def test_merge_component_counters_merges_from_mapper_and_writer() -> None:

--- a/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
+++ b/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
@@ -265,7 +265,7 @@ async def test_progress_snapshot_preserves_completed_logical_units_on_early_init
     def _init_then_fail(dataset: str, resume: bool) -> tuple[str, set[str]]:
         return "run-id", {"AAPL,MSFT"}
 
-    def _fail_queues() -> tuple[
+    async def _fail_queues() -> tuple[
         asyncio.PriorityQueue[tuple[int, int, FetchJob | None]],
         asyncio.Queue[FramePacket | None],
     ]:
@@ -1384,6 +1384,32 @@ async def test_finalize_run_keeps_checkpoint_resumable_when_failures_remain(
     assert checkpoint is not None
     assert checkpoint.status == "in_progress"
     assert checkpoint.failed == ["MSFT"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_run_uses_to_thread_for_run_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+    engine._metrics_enabled = False
+    called: list[str] = []
+
+    async def _noop_flush(*, suppress: bool, consume: bool = True) -> None:
+        return None
+
+    async def _fake_to_thread(func, /, *args, **kwargs):  # type: ignore[no-untyped-def]
+        called.append(getattr(func, "__name__", "call"))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(engine, "_try_flush_once", _noop_flush, raising=True)
+    monkeypatch.setattr(engine, "_update_checkpoint", lambda *args, **kwargs: None, raising=True)
+    monkeypatch.setattr("vertex_forager.core.pipeline.asyncio.to_thread", _fake_to_thread)
+
+    result = RunResult(provider="stub")
+    await engine._finalize_run(result=result, dataset="d", run_id="rid", started_monotonic=time.monotonic() - 1.0)
+
+    assert "<lambda>" in called
+    assert "save_run_history" in called
+    assert result.finished_at is not None
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -3032,7 +3032,7 @@ wheels = [
 
 [[package]]
 name = "vertex-forager"
-version = "0.17.0"
+version = "0.18.0"
 source = { editable = "packages/vertex-forager" }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Converted synchronous blocking I/O operations (`create_run_queues`, `save_run_history`) to run in a thread pool via `asyncio.to_thread` to avoid blocking the event loop
- Made `create_run_queues` in `lifecycle.py` and `_create_run_queues` in `pipeline.py` async

## Linked Issue

- Closes #417

## Changes

- `lifecycle.py`: `create_run_queues` is now `async def`; `cleanup_state_retention` and `cleanup_dlq_tmp` wrapped with `await asyncio.to_thread`
- `pipeline.py`: `_create_run_queues` is now `async def`; `save_run_history` wrapped with `await asyncio.to_thread`
- Updated unit tests to reflect async signatures

## Verification

- `uv run pytest packages/vertex-forager/tests/unit/test_core_lifecycle.py packages/vertex-forager/tests/unit/test_pipeline_coverage.py -v`

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 비동기 작업 처리 방식을 개선하여 이벤트 루프 차단을 방지합니다.
  * 리소스 정리 및 데이터 저장 작업을 백그라운드 스레드에서 처리하도록 최적화했습니다.

* **Tests**
  * 비동기 작업 흐름을 검증하기 위한 테스트 케이스를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->