### PR TITLE
refactor(vertex-forager): dedupe sync client facades

### DIFF
--- a/packages/vertex-forager/examples/minimal_inmemory.py
+++ b/packages/vertex-forager/examples/minimal_inmemory.py
@@ -19,7 +19,7 @@ def main() -> None:
     if provider == "sharadar":
         kwargs["api_key"] = os.environ["SHARADAR_API_KEY"]
     client = create_client(provider=provider, **kwargs)
-    # jupyter_safe wrapper allows sync usage of async methods
+    # Public client methods run through the sync compatibility bridge
     df = client.get_price_data(tickers=tickers, progress=False)
     try:
         print(df.head())  # type: ignore[attr-defined]

--- a/packages/vertex-forager/src/vertex_forager/clients/base.py
+++ b/packages/vertex-forager/src/vertex_forager/clients/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 import asyncio
-from collections.abc import Mapping
+from collections.abc import Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
 from dataclasses import dataclass
 from functools import partial
@@ -32,6 +32,7 @@ from vertex_forager.core.types import JSONValue, SharadarDataset, YFinanceDatase
 from vertex_forager.schema.registry import get_table_schema
 from vertex_forager.utils import (
     Spinner,
+    run_sync_compat,
     sanitize_field,
 )
 from vertex_forager.utils import (
@@ -212,8 +213,11 @@ class BaseClient(ABC, Generic[T]):
             recovery_factor=self._config.throttle.recovery_factor,
             healthy_window_s=self._config.throttle.healthy_window_s,
         )
-        self.last_run: RunResult | None = None
         self._client: httpx.AsyncClient | None = None
+        self.last_run: RunResult | None = None
+
+    def _run_sync_compat(self, coro: Coroutine[Any, Any, Any]) -> Any:
+        return run_sync_compat(coro)
 
     def _build_http_client(self) -> httpx.AsyncClient:
         return build_async_client(

--- a/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py
@@ -25,7 +25,7 @@ from vertex_forager.providers.sharadar.constants import (
 from vertex_forager.providers.sharadar.schema import DATASET_TABLE
 from vertex_forager.routers import create_router
 from vertex_forager.schema.mapper import SchemaMapper
-from vertex_forager.utils import run_sync_compat, validate_tickers
+from vertex_forager.utils import make_sync, validate_tickers
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -180,7 +180,7 @@ class SharadarClient(BaseClient[SharadarDataset]):
     # ----------------------------------------------------------------
     # Public User Methods
     # ----------------------------------------------------------------
-    def get_ticker_info(
+    async def _get_ticker_info_async(
         self,
         *,
         tickers: list[str] | None = None,
@@ -207,25 +207,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_ticker_info_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_ticker_info_async(
-        self,
-        *,
-        tickers: list[str] | None = None,
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         if tickers is None:
             cfg = FetchConfig(
                 dataset="tickers",
@@ -260,7 +241,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_per_ticker(cfg)
 
-    def get_sp500_history(
+    get_ticker_info = make_sync(_get_ticker_info_async)
+
+    async def _get_sp500_history_async(
         self,
         *,
         connect_db: str | Path | None = None,
@@ -284,23 +267,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_sp500_history_async(
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_sp500_history_async(
-        self,
-        *,
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         cfg = self._build_fetch_config(
             dataset="sp500",
             symbols=None,
@@ -317,7 +283,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_pagination(cfg)
 
-    def get_price_data(
+    get_sp500_history = make_sync(_get_sp500_history_async)
+
+    async def _get_price_data_async(
         self,
         *,
         tickers: list[str],
@@ -352,31 +320,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_price_data_async(
-                tickers=tickers,
-                meta=meta,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_price_data_async(
-        self,
-        *,
-        tickers: list[str],
-        meta: str | Path | None = None,
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         self._require_valid_tickers(tickers)
         cfg = self._build_fetch_config(
             dataset="price",
@@ -394,7 +337,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_per_ticker(cfg, ticker_metadata=self._load_ticker_metadata_from_meta_db(meta, tickers))
 
-    def get_fundamental_data(
+    get_price_data = make_sync(_get_price_data_async)
+
+    async def _get_fundamental_data_async(
         self,
         *,
         tickers: list[str],
@@ -429,33 +374,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_fundamental_data_async(
-                tickers=tickers,
-                meta=meta,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                dimension=dimension,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_fundamental_data_async(
-        self,
-        *,
-        tickers: list[str],
-        meta: str | Path | None = None,
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        dimension: str = "MRT",
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         self._require_valid_tickers(tickers)
         extras = {**dict(kwargs), "dimension": dimension}
         cfg = self._build_fetch_config(
@@ -474,7 +392,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_per_ticker(cfg, ticker_metadata=self._load_ticker_metadata_from_meta_db(meta, tickers))
 
-    def get_daily_metrics(
+    get_fundamental_data = make_sync(_get_fundamental_data_async)
+
+    async def _get_daily_metrics_async(
         self,
         *,
         tickers: list[str],
@@ -507,31 +427,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_daily_metrics_async(
-                tickers=tickers,
-                meta=meta,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_daily_metrics_async(
-        self,
-        *,
-        tickers: list[str],
-        meta: str | Path | None = None,
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         self._require_valid_tickers(tickers)
         cfg = self._build_fetch_config(
             dataset="daily",
@@ -549,7 +444,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_per_ticker(cfg, ticker_metadata=self._load_ticker_metadata_from_meta_db(meta, tickers))
 
-    def get_corporate_actions(
+    get_daily_metrics = make_sync(_get_daily_metrics_async)
+
+    async def _get_corporate_actions_async(
         self,
         *,
         tickers: list[str],
@@ -582,31 +479,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_corporate_actions_async(
-                tickers=tickers,
-                meta=meta,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_corporate_actions_async(
-        self,
-        *,
-        tickers: list[str],
-        meta: str | Path | None = None,
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         self._require_valid_tickers(tickers)
         cfg = self._build_fetch_config(
             dataset="actions",
@@ -624,7 +496,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_per_ticker(cfg, ticker_metadata=self._load_ticker_metadata_from_meta_db(meta, tickers))
 
-    def get_insider_transactions(
+    get_corporate_actions = make_sync(_get_corporate_actions_async)
+
+    async def _get_insider_transactions_async(
         self,
         *,
         tickers: list[str],
@@ -657,31 +531,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_insider_transactions_async(
-                tickers=tickers,
-                meta=meta,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_insider_transactions_async(
-        self,
-        *,
-        tickers: list[str],
-        meta: str | Path | None = None,
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         self._require_valid_tickers(tickers)
         cfg = self._build_fetch_config(
             dataset="insider",
@@ -699,7 +548,9 @@ class SharadarClient(BaseClient[SharadarDataset]):
         )
         return await self._fetch_per_ticker(cfg, ticker_metadata=self._load_ticker_metadata_from_meta_db(meta, tickers))
 
-    def get_institutional_ownership(
+    get_insider_transactions = make_sync(_get_insider_transactions_async)
+
+    async def _get_institutional_ownership_async(
         self,
         *,
         tickers: list[str],
@@ -732,31 +583,6 @@ class SharadarClient(BaseClient[SharadarDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_institutional_ownership_async(
-                tickers=tickers,
-                meta=meta,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_institutional_ownership_async(
-        self,
-        *,
-        tickers: list[str],
-        meta: str | Path | None = None,
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: object,
-    ) -> RunResult:
         self._require_valid_tickers(tickers)
         cfg = self._build_fetch_config(
             dataset="institutional",
@@ -773,6 +599,8 @@ class SharadarClient(BaseClient[SharadarDataset]):
             on_progress=on_progress,
         )
         return await self._fetch_per_ticker(cfg, ticker_metadata=self._load_ticker_metadata_from_meta_db(meta, tickers))
+
+    get_institutional_ownership = make_sync(_get_institutional_ownership_async)
 
     # ----------------------------------------------------------------
     # Internal Data Fetchers

--- a/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py
@@ -33,7 +33,7 @@ from vertex_forager.providers.yfinance.constants import (
 from vertex_forager.providers.yfinance.constants import SIZE_MAP as YF_SIZE_MAP
 from vertex_forager.routers import create_router
 from vertex_forager.schema.mapper import SchemaMapper
-from vertex_forager.utils import run_sync_compat, validate_memory_usage, validate_tickers
+from vertex_forager.utils import make_sync, validate_memory_usage, validate_tickers
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -139,7 +139,7 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
 
     # --- Reference Data ---
 
-    def get_info(
+    async def _get_info_async(
         self,
         *,
         tickers: list[str],
@@ -166,25 +166,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_info_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_info_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="info",
             tickers=tickers,
@@ -195,9 +176,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_info = make_sync(_get_info_async)
+
     # --- Market Data ---
 
-    def get_price_data(
+    async def _get_price_data_async(
         self,
         *,
         tickers: list[str],
@@ -231,29 +214,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_price_data_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_price_data_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="price",
             tickers=tickers,
@@ -266,9 +226,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_price_data = make_sync(_get_price_data_async)
+
     # --- Financials ---
 
-    def get_financials(
+    async def _get_financials_async(
         self,
         *,
         kind: Literal["balance_sheet", "income_stmt", "cashflow", "earnings"] = "income_stmt",
@@ -304,29 +266,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_financials_async(
-                kind=kind,
-                period=period,
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_financials_async(
-        self,
-        *,
-        kind: Literal["balance_sheet", "income_stmt", "cashflow", "earnings"] = "income_stmt",
-        period: Literal["annual", "quarterly"] = "annual",
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         target_kind = "financials" if kind in ("income_stmt", "earnings") else kind
         if kind == "earnings":
             logger.warning(
@@ -346,9 +285,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_financials = make_sync(_get_financials_async)
+
     # --- Corporate Actions ---
 
-    def get_actions(
+    async def _get_actions_async(
         self,
         *,
         kind: Literal["dividends", "splits"] = "dividends",
@@ -381,31 +322,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_actions_async(
-                kind=kind,
-                tickers=tickers,
-                connect_db=connect_db,
-                start_date=start_date,
-                end_date=end_date,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_actions_async(
-        self,
-        *,
-        kind: Literal["dividends", "splits"] = "dividends",
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        start_date: str | None = None,
-        end_date: str | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset=cast("YFinanceDataset", kind),
             tickers=tickers,
@@ -418,9 +334,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_actions = make_sync(_get_actions_async)
+
     # --- Holders ---
 
-    def get_holders(
+    async def _get_holders_async(
         self,
         *,
         kind: Literal["institutional", "mutualfund"] = "institutional",
@@ -449,27 +367,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_holders_async(
-                kind=kind,
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_holders_async(
-        self,
-        *,
-        kind: Literal["institutional", "mutualfund"] = "institutional",
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         dataset = f"{kind}_holders"
         return await self._dispatch_fetch(
             dataset=cast("YFinanceDataset", dataset),
@@ -481,7 +378,9 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
-    def get_major_holders(
+    get_holders = make_sync(_get_holders_async)
+
+    async def _get_major_holders_async(
         self,
         *,
         tickers: list[str],
@@ -508,25 +407,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_major_holders_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_major_holders_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="major_holders",
             tickers=tickers,
@@ -537,9 +417,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_major_holders = make_sync(_get_major_holders_async)
+
     # --- Insider ---
 
-    def get_insider_roster_holders(
+    async def _get_insider_roster_holders_async(
         self,
         *,
         tickers: list[str],
@@ -566,25 +448,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_insider_roster_holders_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_insider_roster_holders_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="insider_roster_holders",
             tickers=tickers,
@@ -595,7 +458,9 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
-    def get_insider_purchases(
+    get_insider_roster_holders = make_sync(_get_insider_roster_holders_async)
+
+    async def _get_insider_purchases_async(
         self,
         *,
         tickers: list[str],
@@ -622,25 +487,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_insider_purchases_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_insider_purchases_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="insider_purchases",
             tickers=tickers,
@@ -651,9 +497,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_insider_purchases = make_sync(_get_insider_purchases_async)
+
     # --- Calendar ---
 
-    def get_calendar(
+    async def _get_calendar_async(
         self,
         *,
         tickers: list[str],
@@ -680,25 +528,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_calendar_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_calendar_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="calendar",
             tickers=tickers,
@@ -709,9 +538,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_calendar = make_sync(_get_calendar_async)
+
     # --- Analyst Recommendations ---
 
-    def get_recommendations(
+    async def _get_recommendations_async(
         self,
         *,
         tickers: list[str],
@@ -738,25 +569,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_recommendations_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_recommendations_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="recommendations",
             tickers=tickers,
@@ -767,9 +579,11 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             **kwargs,
         )
 
+    get_recommendations = make_sync(_get_recommendations_async)
+
     # --- news ---
 
-    def get_news(
+    async def _get_news_async(
         self,
         *,
         tickers: list[str],
@@ -796,25 +610,6 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             TransformError: If data normalization fails.
             WriterError: If persistence fails.
         """
-        return run_sync_compat(
-            self._get_news_async(
-                tickers=tickers,
-                connect_db=connect_db,
-                progress=progress,
-                on_progress=on_progress,
-                **kwargs,
-            )
-        )
-
-    async def _get_news_async(
-        self,
-        *,
-        tickers: list[str],
-        connect_db: str | Path | None = None,
-        progress: bool = False,
-        on_progress: Callable[[ProgressSnapshot], None] | None = None,
-        **kwargs: Any,
-    ) -> RunResult:
         return await self._dispatch_fetch(
             dataset="news",
             tickers=tickers,
@@ -824,6 +619,8 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
             on_progress=on_progress,
             **kwargs,
         )
+
+    get_news = make_sync(_get_news_async)
 
     # ----------------------------------------------------------------
     # Internal Data Fetchers

--- a/packages/vertex-forager/src/vertex_forager/utils.py
+++ b/packages/vertex-forager/src/vertex_forager/utils.py
@@ -11,7 +11,7 @@ import shutil
 import sys
 import threading
 import time
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, ParamSpec, Protocol, TypeVar, cast
 import warnings
 
 from dotenv import load_dotenv
@@ -23,7 +23,13 @@ from vertex_forager.core.errors import RunError
 from vertex_forager.exceptions import InputError
 
 logger = logging.getLogger(__name__)
+P = ParamSpec("P")
 T = TypeVar("T")
+R = TypeVar("R")
+
+
+class _SupportsRunSyncCompat(Protocol):
+    def _run_sync_compat(self, coro: Coroutine[Any, Any, R]) -> R: ...
 
 
 def _safe_get_ipython() -> Any:
@@ -722,21 +728,13 @@ def load_env_file(env_file: Path | None = None) -> None:
     load_dotenv(dotenv_path=env_file, override=False)
 
 
-def jupyter_safe(async_func: Callable[..., Any]) -> Callable[..., Any]:
-    """Run an async function in both scripts and Jupyter environments.
-
-    Args:
-        async_func: Async callable to wrap.
-
-    Returns:
-        A callable that returns the awaited result.
-    """
-
+def make_sync(async_func: Callable[P, Coroutine[Any, Any, R]]) -> Callable[P, R]:
     @functools.wraps(async_func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        return run_sync_compat(async_func(*args, **kwargs))
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        self = cast("_SupportsRunSyncCompat", args[0])
+        return self._run_sync_compat(async_func(*args, **kwargs))
 
-    return wrapper
+    return cast("Callable[P, R]", wrapper)
 
 
 def run_sync_compat(coro: Coroutine[Any, Any, T]) -> T:

--- a/packages/vertex-forager/tests/conftest.py
+++ b/packages/vertex-forager/tests/conftest.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from datetime import datetime, timezone
-import importlib
 import json
 import types
 from typing import TYPE_CHECKING, Any
@@ -106,31 +105,16 @@ def sharadar_client(
     """Sharadar client instance with mocked HttpExecutor."""
     from unittest.mock import patch
 
-    # Define a no-op decorator to bypass jupyter_safe
-    def no_op_decorator(func):
-        return func
+    from vertex_forager.providers.sharadar.client import SharadarClient
 
-    # Patch jupyter_safe in the utils module where it is defined
-    with patch("vertex_forager.utils.jupyter_safe", side_effect=no_op_decorator):
-        # Reload the client module to apply the patched decorator
-        import vertex_forager.providers.sharadar.client as client_module
+    with patch("vertex_forager.clients.base.HttpExecutor") as MockHttpExecutorClass:
+        MockHttpExecutorClass.return_value = mock_http_executor
+        client = SharadarClient(
+            api_key=sharadar_client_config["api_key"],
+            rate_limit=sharadar_client_config["rate_limit"],
+        )
 
-        importlib.reload(client_module)
-
-        from vertex_forager.providers.sharadar.client import SharadarClient
-
-        # Patch HttpExecutor in the base client module (where _run is defined)
-        # Ensure that when the client creates an HttpExecutor, it gets our mock
-        with patch("vertex_forager.clients.base.HttpExecutor") as MockHttpExecutorClass:
-            MockHttpExecutorClass.return_value = mock_http_executor
-
-            # Create real client
-            client = SharadarClient(
-                api_key=sharadar_client_config["api_key"],
-                rate_limit=sharadar_client_config["rate_limit"],
-            )
-
-            yield client
+        yield client
 
 
 @pytest.fixture

--- a/packages/vertex-forager/tests/unit/test_quality_rules.py
+++ b/packages/vertex-forager/tests/unit/test_quality_rules.py
@@ -48,6 +48,7 @@ def test_no_future_dates_handles_date_and_datetime_columns() -> None:
         }
     ).with_columns(pl.col("observed_at").cast(pl.Datetime(time_unit="us", time_zone="UTC")))
     rule = NoFutureDates(date_columns=["date", "observed_at"])
+    rule._current_time = lambda: now.astimezone(timezone.utc)  # type: ignore[method-assign]
     violations = rule.validate(df)
     assert len(violations) == 2
     assert any("date" in v for v in violations)

--- a/packages/vertex-forager/tests/unit/test_utils.py
+++ b/packages/vertex-forager/tests/unit/test_utils.py
@@ -27,9 +27,9 @@ from vertex_forager.utils import (  # type: ignore[attr-defined]
     env_int,
     get_app_root,
     get_cache_dir,
-    jupyter_safe,
     load_env_file,
     load_tickers_env,
+    make_sync,
     process_symbols,
     sanitize_field,
     set_env,
@@ -505,21 +505,25 @@ def test_get_app_root_with_env(tmp_path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert root.is_dir()
 
 
-def test_jupyter_safe_sync_and_async_contexts() -> None:
-    async def _afunc(x: int) -> int:
-        return x + 1
+def test_make_sync_sync_and_async_contexts() -> None:
+    class _Dummy:
+        def _run_sync_compat(self, coro):
+            from vertex_forager.utils import run_sync_compat
 
-    safe = jupyter_safe(_afunc)
-    # Sync context (no running loop)
-    assert safe(1) == 2
+            return run_sync_compat(coro)
 
-    # Async context: call inside a running loop
+        async def _afunc(self, x: int) -> int:
+            return x + 1
+
+    safe = make_sync(_Dummy._afunc)
+    dummy = _Dummy()
+    assert safe(dummy, 1) == 2
+
     import asyncio
+    import importlib.util
 
     async def _runner():
-        return safe(2)
-
-    import importlib.util
+        return safe(dummy, 2)
 
     if importlib.util.find_spec("nest_asyncio") is None:
         with pytest.raises(RuntimeError) as excinfo:


### PR DESCRIPTION
## Summary

- Replace duplicated sync facade boilerplate in `SharadarClient` and `YFinanceClient` with a typed `make_sync` helper.
- Keep the private `_get_xxx_async` methods intact for internal async callers while removing dead `jupyter_safe` code.

## Linked Issue

- Closes #424

## Changes

- Add `make_sync` to `utils.py` using `ParamSpec` so sync facade signatures stay aligned with their async implementations under mypy strict.
- Remove the unused `jupyter_safe` helper and replace its old test coverage with `make_sync` coverage.
- Add `_run_sync_compat(...)` to `BaseClient` so client facades can share the same sync bridge logic.
- Replace all public sync facade method bodies in `SharadarClient` with class-level `make_sync(_get_xxx_async)` assignments.
- Replace all public sync facade method bodies in `YFinanceClient` with class-level `make_sync(_get_xxx_async)` assignments.
- Move public method docstrings onto the corresponding `_get_xxx_async` implementations so the async method remains the single source of truth.
- Remove old `jupyter_safe`-specific fixture patching in test setup and update the example comment to describe the sync compatibility bridge.
- Stabilize the existing future-date quality rule test by freezing the rule clock, preventing unrelated time-boundary flakiness during full-suite verification.

## Verification

- `uv run ruff check . --fix`
- `uv run pytest . --cov-fail-under=80`
- `uv run mypy src --strict`
- `uv run python scripts/check_cycles.py`

## Checklist

- [x] ruff/mypy/pytest pass locally
- [x] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 동기 메서드 호출 메커니즘을 개선하여 코드 구조를 단순화했습니다.
  * 내부 호환성 계층의 구현 방식을 최적화하여 유지보수성을 향상했습니다.
  * 테스트 인프라를 정비하여 새로운 구현 방식에 맞춰 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->