### PR TITLE
docs(vertex-forager): document provider authoring and logging contracts

### DIFF
--- a/packages/vertex-forager/docs/explanation/how-built-in-providers-work.md
+++ b/packages/vertex-forager/docs/explanation/how-built-in-providers-work.md
@@ -42,7 +42,7 @@ That means future built-in providers should still be able to share:
 
 This is an internal architecture goal for the package itself, not a statement that normal users are expected to build custom providers as part of the primary workflow.
 
-If you are extending the package with a new built-in provider, use the internal implementation checklist in [provider-authoring.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/explanation/provider-authoring.md). That guide covers the file layout, schema registration, direct dispatch wiring, and test expectations that turn this architecture into a working provider package.
+If you are extending the package with a new built-in provider, use the internal implementation checklist in [provider-authoring.md](./provider-authoring.md). That guide covers the file layout, schema registration, direct dispatch wiring, and test expectations that turn this architecture into a working provider package.
 
 ## What users should expect
 

--- a/packages/vertex-forager/docs/explanation/how-built-in-providers-work.md
+++ b/packages/vertex-forager/docs/explanation/how-built-in-providers-work.md
@@ -42,6 +42,8 @@ That means future built-in providers should still be able to share:
 
 This is an internal architecture goal for the package itself, not a statement that normal users are expected to build custom providers as part of the primary workflow.
 
+If you are extending the package with a new built-in provider, use the internal implementation checklist in [provider-authoring.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/explanation/provider-authoring.md). That guide covers the file layout, schema registration, direct dispatch wiring, and test expectations that turn this architecture into a working provider package.
+
 ## What users should expect
 
 From a user point of view, the most important consequence of this design is consistency. Built-in providers may fetch data differently internally, but they should still feel like one package when you use them.

--- a/packages/vertex-forager/docs/explanation/provider-authoring.md
+++ b/packages/vertex-forager/docs/explanation/provider-authoring.md
@@ -1,0 +1,199 @@
+# Provider authoring
+
+This page documents the internal steps required to add a new built-in provider to `vertex-forager`.
+
+It is written for maintainers of the package, not for end users. Users are expected to consume the built-in providers shipped by the project rather than develop third-party providers as part of the normal workflow.
+
+The current provider shape is intentionally direct:
+
+- a provider package under `src/vertex_forager/providers/<name>/`
+- a `BaseClient` subclass
+- a `BaseRouter` subclass
+- schema definitions registered through `schema/registry.py`
+- client and router wiring in the factory modules
+
+This means a new provider is mostly a matter of creating a predictable set of files and then wiring them into the existing dispatch points.
+
+## 1. Create the provider package
+
+Create a new directory:
+
+```text
+src/vertex_forager/providers/<name>/
+├── __init__.py
+├── client.py
+├── router.py
+├── schema.py
+└── constants.py
+```
+
+Recommended responsibilities:
+
+- `__init__.py`
+  - export the public provider client and router types
+  - keep public package imports stable
+- `client.py`
+  - define the `BaseClient` subclass
+  - validate provider-specific configuration
+  - expose supported datasets and dataset specs
+- `router.py`
+  - define the `BaseRouter` subclass
+  - translate provider-local dataset requests into `RequestSpec`
+  - normalize provider responses into `FramePacket` values
+- `schema.py`
+  - define `TableSchema` and `DatasetSpec` objects
+  - keep provider-facing dataset names mapped to stable internal tables
+- `constants.py`
+  - keep provider-specific defaults, limits, and literal constants out of the client and router bodies
+
+If the provider uses a local library transport instead of plain HTTP, add any extra fetcher or transport adapter file alongside these modules.
+
+## 2. Implement the router contract
+
+Subclass `BaseRouter` and follow the existing built-in examples:
+
+- [yfinance/router.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/router.py)
+- [sharadar/router.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/sharadar/router.py)
+
+The router is responsible for:
+
+- declaring the provider name
+- validating dataset-specific arguments
+- building `RequestSpec` instances
+- parsing responses into normalized `FramePacket` values
+- using the provider schema registry entries to resolve canonical table names
+
+Router tests should focus on parse and request-building behavior:
+
+- request parameter construction
+- paging/batching behavior
+- parse success and parse failure paths
+- unsupported dataset and invalid argument handling
+
+## 3. Implement the client contract
+
+Subclass `BaseClient` in `client.py`.
+
+Every provider client must now implement:
+
+- `get_supported_datasets()`
+- `get_dataset_spec(dataset)`
+
+Those methods are part of the `BaseClient` abstract contract and should reflect the entries registered in `schema/registry.py`.
+
+Use the built-in clients as references:
+
+- [yfinance/client.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py)
+- [sharadar/client.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py)
+
+The client should own:
+
+- provider credentials and configuration validation
+- provider-specific defaults
+- dataset-to-table resolution helpers
+- orchestration helpers that call `run_pipeline(...)`
+
+## 4. Define schemas and datasets
+
+In `schema.py`, define:
+
+- provider `TABLES`
+- provider `DATASETS`
+
+Use:
+
+- `TableSchema` for the internal normalized table contract
+- `DatasetSpec` for the provider-local dataset contract
+
+Pattern examples:
+
+- [yfinance/schema.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/schema.py)
+- [sharadar/schema.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/sharadar/schema.py)
+
+Keep these rules in mind:
+
+- `DatasetSpec.schema` must point at a valid `TableSchema`
+- if `date_filter_col` is omitted, it now defaults from `TableSchema.analysis_date_col`
+- unique keys and date columns should match the normalized sink contract, not the provider payload shape
+
+## 5. Register the provider schema
+
+Add the new provider to [schema/registry.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/schema/registry.py).
+
+You need to:
+
+- import the provider `TABLES` and `DATASETS`
+- merge them into the provider registry maps
+- make sure `get_dataset_spec(...)` and `get_provider_dataset_names(...)` can resolve the new provider
+
+This is the canonical source for provider dataset lookup.
+
+## 6. Wire direct dispatch
+
+### Client factory
+
+Update [clients/__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/clients/__init__.py):
+
+- add lazy registration for the new client
+- add the provider to `create_client(...)`
+- extend any overloads or literal-based return typing as needed
+
+### Router factory
+
+Update [routers/__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/routers/__init__.py):
+
+- add a provider-specific router factory
+- register it in `router_registry`
+
+If the provider uses a local library transport path, also wire any provider fetcher registration alongside the provider package import path.
+
+## 7. Update public typing and exports
+
+Review whether the provider needs updates in:
+
+- [core/types.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/core/types.py)
+- [api.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/api.py)
+- [__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/__init__.py)
+- `providers/<name>/__init__.py`
+
+If the provider introduces a new dataset literal or public client type, keep those exports aligned.
+
+## 8. Update docs and CLI surfaces
+
+Review whether the provider must also be added to:
+
+- [docs/reference/providers.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/reference/providers.md)
+- [docs/explanation/how-built-in-providers-work.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/explanation/how-built-in-providers-work.md)
+- [mkdocs.yml](file:///Users/coolbress/vertex-lab/packages/vertex-forager/mkdocs.yml)
+- [cli.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/cli.py) if the provider is exposed through command groups or provider choices
+
+## 9. Test expectations
+
+At minimum, add:
+
+- router unit tests for request parsing/building
+- router unit tests for response parsing and failure handling
+- schema validation tests for `TableSchema` and `DatasetSpec`
+- client tests for dataset lookup and pipeline wiring where relevant
+
+Also run the local quality gates expected for provider changes:
+
+```bash
+uv run mypy packages/vertex-forager/src --strict
+uv run pytest packages/ --cov-fail-under=80 -q
+NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict
+```
+
+## 10. Provider checklist
+
+- package files created under `providers/<name>/`
+- `BaseRouter` subclass implemented
+- `BaseClient` subclass implemented
+- `get_supported_datasets()` implemented
+- `get_dataset_spec()` implemented
+- schema entries added and registered
+- client dispatch updated
+- router dispatch updated
+- public exports/types updated if needed
+- docs updated
+- tests added and local gates passing

--- a/packages/vertex-forager/docs/explanation/provider-authoring.md
+++ b/packages/vertex-forager/docs/explanation/provider-authoring.md
@@ -52,8 +52,8 @@ If the provider uses a local library transport instead of plain HTTP, add any ex
 
 Subclass `BaseRouter` and follow the existing built-in examples:
 
-- [yfinance/router.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/router.py)
-- [sharadar/router.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/sharadar/router.py)
+- `src/vertex_forager/providers/yfinance/router.py`
+- `src/vertex_forager/providers/sharadar/router.py`
 
 The router is responsible for:
 
@@ -83,8 +83,8 @@ Those methods are part of the `BaseClient` abstract contract and should reflect 
 
 Use the built-in clients as references:
 
-- [yfinance/client.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py)
-- [sharadar/client.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py)
+- `src/vertex_forager/providers/yfinance/client.py`
+- `src/vertex_forager/providers/sharadar/client.py`
 
 The client should own:
 
@@ -107,8 +107,8 @@ Use:
 
 Pattern examples:
 
-- [yfinance/schema.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/schema.py)
-- [sharadar/schema.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/sharadar/schema.py)
+- `src/vertex_forager/providers/yfinance/schema.py`
+- `src/vertex_forager/providers/sharadar/schema.py`
 
 Keep these rules in mind:
 
@@ -118,7 +118,7 @@ Keep these rules in mind:
 
 ## 5. Register the provider schema
 
-Add the new provider to [schema/registry.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/schema/registry.py).
+Add the new provider to `src/vertex_forager/schema/registry.py`.
 
 You need to:
 
@@ -132,7 +132,7 @@ This is the canonical source for provider dataset lookup.
 
 ### Client factory
 
-Update [clients/__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/clients/__init__.py):
+Update `src/vertex_forager/clients/__init__.py`:
 
 - add lazy registration for the new client
 - add the provider to `create_client(...)`
@@ -140,7 +140,7 @@ Update [clients/__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-
 
 ### Router factory
 
-Update [routers/__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/routers/__init__.py):
+Update `src/vertex_forager/routers/__init__.py`:
 
 - add a provider-specific router factory
 - register it in `router_registry`
@@ -151,9 +151,9 @@ If the provider uses a local library transport path, also wire any provider fetc
 
 Review whether the provider needs updates in:
 
-- [core/types.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/core/types.py)
-- [api.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/api.py)
-- [__init__.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/__init__.py)
+- `src/vertex_forager/core/types.py`
+- `src/vertex_forager/api.py`
+- `src/vertex_forager/__init__.py`
 - `providers/<name>/__init__.py`
 
 If the provider introduces a new dataset literal or public client type, keep those exports aligned.
@@ -162,10 +162,10 @@ If the provider introduces a new dataset literal or public client type, keep tho
 
 Review whether the provider must also be added to:
 
-- [docs/reference/providers.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/reference/providers.md)
-- [docs/explanation/how-built-in-providers-work.md](file:///Users/coolbress/vertex-lab/packages/vertex-forager/docs/explanation/how-built-in-providers-work.md)
-- [mkdocs.yml](file:///Users/coolbress/vertex-lab/packages/vertex-forager/mkdocs.yml)
-- [cli.py](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/cli.py) if the provider is exposed through command groups or provider choices
+- `docs/reference/providers.md`
+- `docs/explanation/how-built-in-providers-work.md`
+- `mkdocs.yml`
+- `src/vertex_forager/cli.py` if the provider is exposed through command groups or provider choices
 
 ## 9. Test expectations
 

--- a/packages/vertex-forager/docs/reference/logging-schema.md
+++ b/packages/vertex-forager/docs/reference/logging-schema.md
@@ -1,0 +1,122 @@
+# Logging schema
+
+This page documents the structured log fields that `vertex-forager` currently emits through `logging` `extra=` payloads.
+
+Use this reference when building dashboards, alerting rules, or log processors.
+
+## Conventions
+
+- Field names use the `vf_` prefix.
+- String identifiers are sanitized before emission.
+- Durations are emitted in seconds.
+- Counts are emitted as integers.
+
+## Core fields
+
+These fields are the stable core of structured stage logs.
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `vf_provider` | `str` | Provider identifier such as `yfinance` or `sharadar`. |
+| `vf_dataset` | `str` | Provider-local dataset name. |
+| `vf_symbol` | `str` | Single symbol, `*`, or sanitized symbol placeholder. |
+| `vf_stage` | `str` | Event/stage name. |
+| `vf_attempt` | `int` | Attempt counter for the event. |
+| `vf_duration_s` | `float \| None` | Duration in seconds when known. |
+
+## Event categories
+
+### Client run start
+
+Source: [BaseClient.run_pipeline](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/clients/base.py)
+
+Guaranteed fields:
+
+- `vf_provider: str`
+- `vf_dataset: str`
+- `vf_symbol: "*"`
+- `vf_stage: "client_run_start"`
+- `vf_symbols: int`
+- `vf_attempt: int`
+- `vf_duration_s: 0.0`
+
+### Client run complete
+
+Source: [BaseClient.run_pipeline](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/clients/base.py)
+
+Guaranteed fields:
+
+- `vf_provider: str`
+- `vf_dataset: str`
+- `vf_symbol: "*"`
+- `vf_stage: "client_run_end"`
+- `vf_errors: int`
+- `vf_attempt: int`
+- `vf_duration_s: float`
+
+### Fetch and pipeline stage events
+
+Source: [VertexForager._log_structured](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/core/pipeline.py)
+
+Guaranteed fields:
+
+- `vf_provider: str`
+- `vf_dataset: str`
+- `vf_symbol: str`
+- `vf_stage: str`
+- `vf_attempt: int`
+- `vf_duration_s: float | None`
+
+Typical stage values include fetch start, fetch completion, parse completion, write completion, and error stages. The exact stage value is part of the event payload and should be matched as a string rather than inferred from the logger name.
+
+### Router packet completion
+
+Source: [YFinanceRouter._log_structured](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/router.py)
+
+Guaranteed fields:
+
+- `vf_provider: str`
+- `vf_dataset: str`
+- `vf_symbol: str`
+- `vf_stage: str`
+- `vf_attempt: int`
+- `vf_duration_s: float`
+- `vf_packets: int`
+
+Optional fields:
+
+- `vf_rows: int`
+
+### Pipeline summary
+
+Source: [emit_pipeline_summary](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/core/lifecycle.py)
+
+Guaranteed fields:
+
+- `vf_provider: str`
+- `vf_dataset: str`
+- `vf_symbol: "*"`
+- `vf_stage: "pipeline_summary"`
+- `vf_attempt: 0`
+- `vf_duration_s: float`
+
+Additional summary metrics are emitted as dynamic integer fields with the prefix `vf_`, for example:
+
+- `vf_jobs_completed`
+- `vf_rows_written`
+- `vf_errors`
+- `vf_dlq_spooled_total`
+
+Treat these as summary counters rather than per-record dimensions.
+
+## Write and DLQ events
+
+Dedicated structured write-success, write-error, DLQ enqueue, and DLQ drain events are not emitted as separate logger schemas today.
+
+Current operator guidance:
+
+- use pipeline stage logs for per-attempt write/fetch progress
+- use pipeline summary counters for final write/DLQ totals
+- use `RunResult.errors` and DLQ state for detailed failure inspection
+
+If new dedicated write or DLQ structured events are added later, they should extend this page with field-level guarantees before shipping.

--- a/packages/vertex-forager/docs/reference/logging-schema.md
+++ b/packages/vertex-forager/docs/reference/logging-schema.md
@@ -28,7 +28,7 @@ These fields are the stable core of structured stage logs.
 
 ### Client run start
 
-Source: [BaseClient.run_pipeline](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/clients/base.py)
+Source: `BaseClient.run_pipeline` in `src/vertex_forager/clients/base.py`
 
 Guaranteed fields:
 
@@ -42,7 +42,7 @@ Guaranteed fields:
 
 ### Client run complete
 
-Source: [BaseClient.run_pipeline](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/clients/base.py)
+Source: `BaseClient.run_pipeline` in `src/vertex_forager/clients/base.py`
 
 Guaranteed fields:
 
@@ -56,7 +56,7 @@ Guaranteed fields:
 
 ### Fetch and pipeline stage events
 
-Source: [VertexForager._log_structured](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/core/pipeline.py)
+Source: `VertexForager._log_structured` in `src/vertex_forager/core/pipeline.py`
 
 Guaranteed fields:
 
@@ -71,7 +71,7 @@ Typical stage values include fetch start, fetch completion, parse completion, wr
 
 ### Router packet completion
 
-Source: [YFinanceRouter._log_structured](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/providers/yfinance/router.py)
+Source: `YFinanceRouter._log_structured` in `src/vertex_forager/providers/yfinance/router.py`
 
 Guaranteed fields:
 
@@ -89,7 +89,7 @@ Optional fields:
 
 ### Pipeline summary
 
-Source: [emit_pipeline_summary](file:///Users/coolbress/vertex-lab/packages/vertex-forager/src/vertex_forager/core/lifecycle.py)
+Source: `emit_pipeline_summary` in `src/vertex_forager/core/lifecycle.py`
 
 Guaranteed fields:
 

--- a/packages/vertex-forager/docs/reference/logging-schema.md
+++ b/packages/vertex-forager/docs/reference/logging-schema.md
@@ -7,7 +7,7 @@ Use this reference when building dashboards, alerting rules, or log processors.
 ## Conventions
 
 - Field names use the `vf_` prefix.
-- String identifiers are sanitized before emission.
+- String identifiers are sanitized before emission with the current `sanitize_field(...)` rules: `None` becomes an empty string, runs of whitespace become `_`, `=` becomes `_`, repeated underscores collapse to a single `_`, and leading or trailing underscores are removed. Example: `"  AAPL = US  "` becomes `AAPL_US`. There is currently no lowercase normalization or max-length truncation.
 - Durations are emitted in seconds.
 - Counts are emitted as integers.
 
@@ -23,6 +23,8 @@ These fields are the stable core of structured stage logs.
 | `vf_stage` | `str` | Event/stage name. |
 | `vf_attempt` | `int` | Attempt counter for the event. |
 | `vf_duration_s` | `float \| None` | Duration in seconds when known. |
+
+Treat `vf_duration_s` as optional in the general schema, but note that some event categories are stricter: `client_run_start` always emits `0.0`, while `client_run_end`, router packet logs, and pipeline summary logs emit a concrete `float`. Fetch and pipeline stage events may still emit `None` when duration is not yet known.
 
 ## Event categories
 
@@ -71,7 +73,7 @@ Typical stage values include fetch start, fetch completion, parse completion, wr
 
 ### Router packet completion
 
-Source: `YFinanceRouter._log_structured` in `src/vertex_forager/providers/yfinance/router.py`
+Source: `YFinanceRouter._emit_structured_parse_log` in `src/vertex_forager/providers/yfinance/router.py`
 
 Guaranteed fields:
 
@@ -89,7 +91,7 @@ Optional fields:
 
 ### Pipeline summary
 
-Source: `emit_pipeline_summary` in `src/vertex_forager/core/lifecycle.py`
+Source: `emit_pipeline_summary_log` in `src/vertex_forager/core/lifecycle.py`
 
 Guaranteed fields:
 

--- a/packages/vertex-forager/mkdocs.yml
+++ b/packages/vertex-forager/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Migration Guide: how-to/migration.md
   - Reference:
       - Providers: reference/providers.md
+      - Logging schema: reference/logging-schema.md
       - StateManager: reference/statemanager.md
       - CLI: reference/cli.md
       - API: reference/api.md
@@ -30,6 +31,7 @@ nav:
       - Pipeline architecture: explanation/architecture.md
       - How pipeline orchestrates: explanation/how-pipeline-orchestrates.md
       - How built-in providers work: explanation/how-built-in-providers-work.md
+      - Provider authoring: explanation/provider-authoring.md
       - How flow controller works: explanation/how-flow-controller-works.md
       - How retry and backoff work: explanation/how-retry-and-backoff-work.md
       - How data quality rules work: explanation/how-data-quality-rules-work.md

--- a/packages/vertex-forager/src/vertex_forager/clients/base.py
+++ b/packages/vertex-forager/src/vertex_forager/clients/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from abc import ABC
+from abc import ABC, abstractmethod
 import asyncio
 from collections.abc import Coroutine, Mapping
 from contextlib import AsyncExitStack, asynccontextmanager, nullcontext
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     import httpx
 
     from vertex_forager.core.contracts import IMapper, IRouter, IWriter
+    from vertex_forager.schema.config import DatasetSpec
     from vertex_forager.writers.base import BaseWriter
 
 HttpExecutor = _HttpExecutor
@@ -331,6 +332,37 @@ class BaseClient(ABC, Generic[T]):
         except (TypeError, ValueError):
             logger.debug("bad attempt value: %s", value)
             return 0
+
+    @abstractmethod
+    def get_supported_datasets(self) -> tuple[T, ...]:
+        """Return the provider-local dataset names supported by this client.
+
+        Returns:
+            tuple[T, ...]: Immutable tuple of provider-local dataset identifiers
+                accepted by this client's collection methods and routers.
+
+        Raises:
+            RuntimeError: If a subclass cannot resolve its dataset registry at
+                runtime due to an internal configuration or import problem.
+        """
+
+    @abstractmethod
+    def get_dataset_spec(self, dataset: T) -> DatasetSpec:
+        """Return the canonical dataset contract for a provider-local dataset.
+
+        Args:
+            dataset: Provider-local dataset identifier such as `"price"` or
+                `"fundamental"`.
+
+        Returns:
+            DatasetSpec: The registered dataset contract describing endpoint,
+                target schema, and request-side date filtering behavior.
+
+        Raises:
+            KeyError: If the dataset is not supported by this client.
+            RuntimeError: If the dataset registry cannot be resolved because of
+                an internal configuration or import problem.
+        """
 
     async def run_pipeline(
         self,

--- a/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/sharadar/client.py
@@ -23,7 +23,7 @@ from vertex_forager.providers.sharadar.constants import (
 )
 from vertex_forager.routers import create_router
 from vertex_forager.schema.mapper import SchemaMapper
-from vertex_forager.schema.registry import get_dataset_spec
+from vertex_forager.schema.registry import get_dataset_spec, get_provider_dataset_names
 from vertex_forager.utils import make_sync, validate_tickers
 
 if TYPE_CHECKING:
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         SchedulerConfig,
         StorageConfig,
     )
+    from vertex_forager.schema.config import DatasetSpec
 
 logger = logging.getLogger(__name__)
 
@@ -145,10 +146,17 @@ class SharadarClient(BaseClient[SharadarDataset]):
         return df.unique(subset=["ticker"], keep="last", maintain_order=True)
 
     def _table_name_for_dataset(self, dataset: SharadarDataset) -> str:
+        spec = self.get_dataset_spec(dataset)
+        return spec.schema.table
+
+    def get_supported_datasets(self) -> tuple[SharadarDataset, ...]:
+        return cast("tuple[SharadarDataset, ...]", tuple(get_provider_dataset_names("sharadar")))
+
+    def get_dataset_spec(self, dataset: SharadarDataset) -> DatasetSpec:
         spec = get_dataset_spec("sharadar", dataset)
         if spec is None:
-            raise InputError(f"Unsupported Sharadar dataset: {dataset}")
-        return spec.schema.table
+            raise KeyError(f"Unsupported dataset: {dataset}")
+        return spec
 
     # ----------------------------------------------------------------
     # Public User Methods

--- a/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py
@@ -138,10 +138,7 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
         self._mapper = SchemaMapper()
 
     def _table_name_for_dataset(self, dataset: YFinanceDataset) -> str:
-        spec = self.get_dataset_spec(dataset)
-        if spec is None:
-            raise InputError(f"Unsupported YFinance dataset: {dataset}")
-        return spec.schema.table
+        return self.get_dataset_spec(dataset).schema.table
 
     def get_supported_datasets(self) -> tuple[YFinanceDataset, ...]:
         return cast("tuple[YFinanceDataset, ...]", tuple(get_provider_dataset_names("yfinance")))

--- a/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/yfinance/client.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from vertex_forager.clients.base import BaseClient
 from vertex_forager.constants import (
@@ -34,7 +34,7 @@ from vertex_forager.providers.yfinance.constants import (
 from vertex_forager.providers.yfinance.constants import SIZE_MAP as YF_SIZE_MAP
 from vertex_forager.routers import create_router
 from vertex_forager.schema.mapper import SchemaMapper
-from vertex_forager.schema.registry import get_dataset_spec
+from vertex_forager.schema.registry import get_dataset_spec, get_provider_dataset_names
 from vertex_forager.utils import make_sync, validate_memory_usage, validate_tickers
 
 if TYPE_CHECKING:
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
 
     from vertex_forager.core.checkpoint import Checkpoint
     from vertex_forager.core.config import ProgressSnapshot
+    from vertex_forager.schema.config import DatasetSpec
 
 logger = logging.getLogger(__name__)
 
@@ -137,10 +138,19 @@ class YFinanceClient(BaseClient[YFinanceDataset]):
         self._mapper = SchemaMapper()
 
     def _table_name_for_dataset(self, dataset: YFinanceDataset) -> str:
-        spec = get_dataset_spec("yfinance", dataset)
+        spec = self.get_dataset_spec(dataset)
         if spec is None:
             raise InputError(f"Unsupported YFinance dataset: {dataset}")
         return spec.schema.table
+
+    def get_supported_datasets(self) -> tuple[YFinanceDataset, ...]:
+        return cast("tuple[YFinanceDataset, ...]", tuple(get_provider_dataset_names("yfinance")))
+
+    def get_dataset_spec(self, dataset: YFinanceDataset) -> DatasetSpec:
+        spec = get_dataset_spec("yfinance", dataset)
+        if spec is None:
+            raise KeyError(f"Unsupported dataset: {dataset}")
+        return spec
 
     # ----------------------------------------------------------------
     # Public User Methods

--- a/packages/vertex-forager/tests/unit/test_sharadar_init_lazy_import.py
+++ b/packages/vertex-forager/tests/unit/test_sharadar_init_lazy_import.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+from vertex_forager.schema.registry import get_dataset_spec
+
 
 class TestSharadarInitLazyExport:
     """Tests for vertex_forager.providers.sharadar lazy-export behavior."""
@@ -51,3 +53,13 @@ class TestSharadarInitLazyExport:
         _ = mod.SharadarRouter
         assert "vertex_forager.providers.sharadar.client" in sys.modules
         assert "vertex_forager.providers.sharadar.router" in sys.modules
+
+    def test_client_exposes_dataset_contracts(self) -> None:
+        from vertex_forager.providers.sharadar.client import SharadarClient
+
+        client = SharadarClient(api_key="demo", rate_limit=60)
+
+        datasets = client.get_supported_datasets()
+
+        assert "price" in datasets
+        assert client.get_dataset_spec("price") == get_dataset_spec("sharadar", "price")

--- a/packages/vertex-forager/tests/unit/test_yfinance_client.py
+++ b/packages/vertex-forager/tests/unit/test_yfinance_client.py
@@ -8,6 +8,7 @@ import pytest
 
 from vertex_forager.clients import create_client
 from vertex_forager.exceptions import InputError
+from vertex_forager.schema.registry import get_dataset_spec
 
 try:
     from vertex_forager.providers.yfinance.client import YFinanceClient
@@ -61,6 +62,14 @@ class TestYFinanceClientDefaults:
                 provider="yfinance",
                 api_key="user_supplied",
             )
+
+    def test_client_exposes_dataset_contracts(self) -> None:
+        client = YFinanceClient()
+
+        datasets = client.get_supported_datasets()
+
+        assert "price" in datasets
+        assert client.get_dataset_spec("price") == get_dataset_spec("yfinance", "price")
 
 
 class TestYFinanceRouterDateParams:


### PR DESCRIPTION
## Summary

- Add maintainer-facing documentation for how a new built-in provider should be added after the provider architecture simplifications.
- Add a structured logging schema reference that documents the currently emitted `vf_*` fields and their guarantees.
- Formalize provider dataset lookup on `BaseClient` by adding abstract `get_supported_datasets()` and `get_dataset_spec()` contracts and implementing them in the built-in clients.
- This is needed because issue #465 identified three remaining gaps: no internal provider authoring guide, no structured logging field schema reference, and no enforced `BaseClient` contract for dataset discovery/spec lookup.

## Linked Issue

- Closes #465

## Changes

- Add internal provider authoring documentation:
  - `packages/vertex-forager/docs/explanation/provider-authoring.md`
- Add structured logging field reference:
  - `packages/vertex-forager/docs/reference/logging-schema.md`
- Update built-in provider architecture explanation to point to the new internal provider authoring page:
  - `packages/vertex-forager/docs/explanation/how-built-in-providers-work.md`
- Update MkDocs navigation:
  - add `Provider authoring` under `Explanation`
  - add `Logging schema` under `Reference`
- Add abstract methods with full docstrings to `BaseClient`:
  - `get_supported_datasets()`
  - `get_dataset_spec(dataset)`
- Implement the new abstract methods in:
  - `YFinanceClient`
  - `SharadarClient`
- Add or update provider client contract tests in existing provider test files rather than keeping a separate one-off Sharadar test file.

## Verification

- Ran:
  - `uv run pytest packages/ --cov-fail-under=80 -q`
  - `uv run mypy packages/vertex-forager/src --strict`
  - `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
  - `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict`
  - `uv run python scripts/check_cycles.py`
- Results:
  - `505 passed`
  - mypy passed
  - ruff passed
  - MkDocs strict build passed
  - import cycle check passed

## Checklist

- [x] ruff/mypy/pytest pass locally
- [x] Docs updated (if user‑visible)
- [ ] Changelog entry (if user‑visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 구조화된 로깅 스키마 참조 문서 추가
  * 내장 프로바이더 작성 안내 문서 및 설명 페이지 추가
  * MkDocs 네비게이션에 새 문서들 포함

* **New Features**
  * 클라이언트 API에 지원 데이터셋 열거 및 데이터셋 사양 조회 기능 추가
  * 기존 제공자들에 대한 데이터셋 탐지·사양 노출 구현

* **Tests**
  * 클라이언트의 데이터셋 발견 및 사양 일치성 검증 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->