### PR TITLE
docs(vertex-forager): fix installation and quickstart accuracy

### DIFF
--- a/packages/vertex-forager/docs/index.md
+++ b/packages/vertex-forager/docs/index.md
@@ -26,7 +26,7 @@ vertex-forager handles the operational complexity so you can focus on the data:
 ## Installation
 
 ```bash
-pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
+pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.30.9#subdirectory=packages/vertex-forager"
 ```
 
 vertex-forager is currently distributed from GitHub rather than PyPI. The example below uses the yfinance provider, so the install snippet includes the `yfinance` extra. See [Installation](installation.md) for other install variants, extras, and repository-based workflows.

--- a/packages/vertex-forager/docs/installation.md
+++ b/packages/vertex-forager/docs/installation.md
@@ -7,18 +7,17 @@ Use `vertex-forager` when you want a packaged entrypoint for data collection, no
 ## Install From GitHub
 
 ```bash
-pip install "vertex-forager @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
+pip install "vertex-forager @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.30.9#subdirectory=packages/vertex-forager"
 ```
 
 ## Optional Extras
 
 ```bash
-pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
-pip install "vertex-forager[notebook] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
+pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.30.9#subdirectory=packages/vertex-forager"
 ```
 
 - `yfinance` installs the library-backed provider dependencies: `pandas` and `yfinance`
-- `notebook` installs the notebook runtime dependencies: `ipywidgets`, `ipython`, and `nest-asyncio`
+- For notebooks, prefer the repository workflow below (`uv sync --group dev`) or install your preferred notebook runtime separately.
 
 You can also install from a wheel or sdist attached to [GitHub Releases](https://github.com/coolbress/VertexLab/releases).
 

--- a/packages/vertex-forager/docs/tutorials/quickstart.md
+++ b/packages/vertex-forager/docs/tutorials/quickstart.md
@@ -8,14 +8,10 @@ Follow this tutorial from a minimal in-memory example to a local DuckDB-backed b
 - Install the package from GitHub:
 
 ```bash
-pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
+pip install "vertex-forager[yfinance] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.30.9#subdirectory=packages/vertex-forager"
 ```
 
-- Optional notebook extras:
-
-```bash
-pip install "vertex-forager[notebook] @ git+https://github.com/coolbress/VertexLab.git@vertex-forager-v0.11.4#subdirectory=packages/vertex-forager"
-```
+- For notebook workflows, use the repository workflow from [Installation](../installation.md) or install your preferred notebook runtime separately.
 
 ## 1. Create a client
 
@@ -44,14 +40,15 @@ client = create_client(
 
 ## 2. Fetch data into memory
 
-If you do not pass `connect_db`, the result stays in memory and you get a Polars DataFrame back immediately.
+If you do not pass `connect_db`, the result stays in memory and `get_price_data(...)` returns `RunResult` with the Polars DataFrame in `result.data`.
 
 ```python
 from vertex_forager import create_client
 
 client = create_client(provider="yfinance")
-prices = client.get_price_data(tickers=["AAPL", "MSFT"])
-print(prices.head())
+result = client.get_price_data(tickers=["AAPL", "MSFT"])
+if result.data is not None:
+    print(result.data.head())
 ```
 
 This is the right stopping point if you only need a DataFrame for analysis or ad hoc exploration.
@@ -66,7 +63,7 @@ from vertex_forager import create_client
 client = create_client(provider="yfinance")
 run = client.get_price_data(
     tickers=["AAPL", "MSFT"],
-    connect_db="duckdb://./forager.duckdb",
+    connect_db="duckdb:///forager.duckdb",
 )
 print(run.tables)
 print(run.errors)


### PR DESCRIPTION
## Summary

- Update GitHub install examples to the current `vertex-forager-v0.30.9` release tag.
- Remove the documented `[notebook]` extra that does not exist and point notebook users to the repo workflow instead.
- Fix quickstart so the in-memory example correctly uses `RunResult.data` and align DuckDB URI examples with the current writer behavior.

## Linked Issue

- Closes #472

## Changes

- Update `packages/vertex-forager/docs/installation.md`
  - replace stale `vertex-forager-v0.11.4` install snippets with `vertex-forager-v0.30.9`
  - remove the nonexistent `[notebook]` install extra example
  - clarify notebook guidance via the repo workflow / separate runtime install
- Update `packages/vertex-forager/docs/tutorials/quickstart.md`
  - replace stale install tag with `vertex-forager-v0.30.9`
  - remove nonexistent `[notebook]` extra instructions
  - fix the in-memory example to use `RunResult.data.head()` instead of `prices.head()`
  - correct the surrounding text to say `get_price_data(...)` returns `RunResult`
  - align the persisted DuckDB URI example to `duckdb:///forager.duckdb`
- Update `packages/vertex-forager/docs/index.md`
  - replace the stale install tag with `vertex-forager-v0.30.9`

## Verification

- Ran:
  - `NO_MKDOCS_2_WARNING=1 uv run mkdocs build --strict`
  - `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
  - `uv run mypy packages/vertex-forager/src --strict`
- Results:
  - mkdocs strict build: pass
  - ruff: pass
  - mypy: pass

## Checklist

- [x] Docs updated
- [x] CI gates pass locally
- [x] No code behavior change intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 문서

* 설치 명령어를 최신 버전으로 업데이트
* 노트북 설정 안내 방식 개선
* 빠른 시작 가이드 및 API 사용 예시 갱신

<!-- end of auto-generated comment: release notes by coderabbit.ai -->