### PR TITLE
refactor(vertex-forager): remove provider import edges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,14 +302,26 @@ jobs:
         env:
           VF_PROFILE_OUTPUT_DIR: ${{ github.workspace }}/output/forager-profiles
         run: uv run python packages/vertex-forager/tests/verification/verify_pipeline_perf.py
+      - name: Detect benchmark metrics artifact
+        id: benchmark-metrics
+        shell: bash
+        run: |
+          path="${{ github.workspace }}/output/forager-profiles/profile_metrics.json"
+          if [ -f "$path" ]; then
+            echo "has_metrics=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_metrics=false" >> "$GITHUB_OUTPUT"
+            echo "Benchmark metrics missing; skipping compare/upload."
+          fi
       - name: Compare benchmark against baseline
+        if: ${{ steps.benchmark-metrics.outputs.has_metrics == 'true' }}
         env:
           VF_PROFILE_OUTPUT_DIR: ${{ github.workspace }}/output/forager-profiles
           BENCHMARK_METRIC_PATH: duration_s
           BENCHMARK_MAX_REGRESSION: "0.30"
         run: uv run python .github/scripts/compare_benchmark_metrics.py
       - name: Upload benchmark metrics artifact
-        if: ${{ always() }}
+        if: ${{ always() && steps.benchmark-metrics.outputs.has_metrics == 'true' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0 pinned
         with:
           name: benchmark-profile-metrics

--- a/packages/vertex-forager/src/vertex_forager/constants_view.py
+++ b/packages/vertex-forager/src/vertex_forager/constants_view.py
@@ -4,6 +4,8 @@ import json
 import os
 from typing import Any
 
+from vertex_forager.providers.catalog import get_provider_constants_preview
+
 
 def _global_constants_map(constants_mod: Any) -> dict[str, object]:
     return {
@@ -52,10 +54,9 @@ def _collect_env_overrides() -> dict[str, object]:
 
 def build_constants_preview(section: str) -> dict[str, dict[str, object]]:
     from vertex_forager import constants as global_constants
-    from vertex_forager.providers.sharadar import constants as sh_constants
-    from vertex_forager.providers.yfinance import constants as yf_constants
 
     preview: dict[str, dict[str, object]] = {}
+    provider_preview = get_provider_constants_preview()
     if section in ("global", "all"):
         preview["global"] = _global_constants_map(constants_mod=global_constants)
     if section in ("flow", "all"):
@@ -63,25 +64,9 @@ def build_constants_preview(section: str) -> dict[str, dict[str, object]]:
     if section in ("queue", "all"):
         preview["queue"] = _queue_constants_map(constants_mod=global_constants)
     if section in ("yfinance", "all"):
-        preview["yfinance"] = {
-            "PRICE_BATCH_SIZE": yf_constants.PRICE_BATCH_SIZE,
-            "PRICE_BATCH_MAX": yf_constants.PRICE_BATCH_MAX,
-            "THREADS_THRESHOLD": yf_constants.THREADS_THRESHOLD,
-            "PRICE_BATCH_SIZE_KEY": yf_constants.PRICE_BATCH_SIZE_KEY,
-            "DEFAULT_INTERVAL": yf_constants.DEFAULT_INTERVAL,
-            "DEFAULT_PRICE_PERIOD": yf_constants.DEFAULT_PRICE_PERIOD,
-        }
+        preview["yfinance"] = provider_preview["yfinance"]
     if section in ("sharadar", "all"):
-        preview["sharadar"] = {
-            "MAX_ROWS_PER_REQUEST": sh_constants.MAX_ROWS_PER_REQUEST,
-            "DEFAULT_BATCH_SIZE": sh_constants.DEFAULT_BATCH_SIZE,
-            "MIN_BATCH_SIZE": sh_constants.MIN_BATCH_SIZE,
-            "TRADING_DAYS_RATIO": sh_constants.TRADING_DAYS_RATIO,
-            "QUARTERLY_DAYS_RATIO": sh_constants.QUARTERLY_DAYS_RATIO,
-            "PAGINATION_META_KEY": sh_constants.PAGINATION_META_KEY,
-            "PAGINATION_CURSOR_PARAM": sh_constants.PAGINATION_CURSOR_PARAM,
-            "MAX_PAGES": sh_constants.MAX_PAGES,
-        }
+        preview["sharadar"] = provider_preview["sharadar"]
     if section in ("writers", "all"):
         preview["writers"] = {
             "WRITER_DUCKDB_MAX_WORKERS": global_constants.WRITER_DUCKDB_MAX_WORKERS,

--- a/packages/vertex-forager/src/vertex_forager/constants_view.py
+++ b/packages/vertex-forager/src/vertex_forager/constants_view.py
@@ -56,7 +56,7 @@ def build_constants_preview(section: str) -> dict[str, dict[str, object]]:
     from vertex_forager import constants as global_constants
 
     preview: dict[str, dict[str, object]] = {}
-    provider_preview = get_provider_constants_preview()
+    provider_preview: dict[str, dict[str, object]] | None = None
     if section in ("global", "all"):
         preview["global"] = _global_constants_map(constants_mod=global_constants)
     if section in ("flow", "all"):
@@ -64,8 +64,12 @@ def build_constants_preview(section: str) -> dict[str, dict[str, object]]:
     if section in ("queue", "all"):
         preview["queue"] = _queue_constants_map(constants_mod=global_constants)
     if section in ("yfinance", "all"):
+        if provider_preview is None:
+            provider_preview = get_provider_constants_preview()
         preview["yfinance"] = provider_preview["yfinance"]
     if section in ("sharadar", "all"):
+        if provider_preview is None:
+            provider_preview = get_provider_constants_preview()
         preview["sharadar"] = provider_preview["sharadar"]
     if section in ("writers", "all"):
         preview["writers"] = {

--- a/packages/vertex-forager/src/vertex_forager/exceptions.py
+++ b/packages/vertex-forager/src/vertex_forager/exceptions.py
@@ -9,13 +9,6 @@ try:
 except ImportError:
     HAS_HTTPX = False
 
-try:
-    import requests
-
-    HAS_REQUESTS = True
-except ImportError:
-    HAS_REQUESTS = False
-
 from vertex_forager.core.retry_policy import DEFAULT_RETRY_STATUS_CODES, is_retryable_status_code
 
 
@@ -210,15 +203,9 @@ class RunError:
             return True
         if HAS_HTTPX and isinstance(exc, httpx.TransportError):
             return True
-        return HAS_REQUESTS and isinstance(
-            exc,
-            (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.Timeout,
-                requests.exceptions.ConnectTimeout,
-                requests.exceptions.ReadTimeout,
-            ),
-        )
+        from vertex_forager.providers.yfinance.errors import is_retryable_yfinance_error
+
+        return is_retryable_yfinance_error(exc)
 
 
 __all__ = [

--- a/packages/vertex-forager/src/vertex_forager/exceptions.py
+++ b/packages/vertex-forager/src/vertex_forager/exceptions.py
@@ -165,7 +165,9 @@ class RunError:
     ) -> RunError:
         exc_type = f"{exc.__class__.__module__}.{exc.__class__.__name__}"
         message = str(exc)
-        retryable = any(cls._is_retryable_error(candidate) for candidate in cls._iter_exception_chain(exc))
+        retryable = any(
+            cls._is_retryable_error(candidate, provider=provider) for candidate in cls._iter_exception_chain(exc)
+        )
         return cls(
             provider=provider,
             dataset=dataset,
@@ -188,7 +190,7 @@ class RunError:
         return chain
 
     @staticmethod
-    def _is_retryable_error(exc: Exception) -> bool:
+    def _is_retryable_error(exc: Exception, *, provider: str) -> bool:
         if hasattr(exc, "response") and exc.response is not None and hasattr(exc.response, "status_code"):
             status_code = exc.response.status_code
             if is_retryable_status_code(status_code, DEFAULT_RETRY_STATUS_CODES):
@@ -203,6 +205,8 @@ class RunError:
             return True
         if HAS_HTTPX and isinstance(exc, httpx.TransportError):
             return True
+        if provider != "yfinance":
+            return False
         from vertex_forager.providers.yfinance.errors import is_retryable_yfinance_error
 
         return is_retryable_yfinance_error(exc)

--- a/packages/vertex-forager/src/vertex_forager/providers/catalog.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/catalog.py
@@ -1,0 +1,64 @@
+"""Built-in provider catalog for schemas and preview constants."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from vertex_forager.schema.config import DatasetSpec, TableSchema
+
+
+def get_provider_tables() -> dict[str, Mapping[str, TableSchema]]:
+    sharadar_schema = import_module("vertex_forager.providers.sharadar.schema")
+    yfinance_schema = import_module("vertex_forager.providers.yfinance.schema")
+
+    return {
+        "sharadar": sharadar_schema.TABLES,
+        "yfinance": yfinance_schema.TABLES,
+    }
+
+
+def get_provider_datasets() -> dict[str, Sequence[DatasetSpec]]:
+    sharadar_schema = import_module("vertex_forager.providers.sharadar.schema")
+    yfinance_schema = import_module("vertex_forager.providers.yfinance.schema")
+
+    return {
+        "sharadar": sharadar_schema.DATASETS,
+        "yfinance": yfinance_schema.DATASETS,
+    }
+
+
+def get_provider_constants_preview() -> dict[str, dict[str, object]]:
+    sh_constants = import_module("vertex_forager.providers.sharadar.constants")
+    yf_constants = import_module("vertex_forager.providers.yfinance.constants")
+
+    return {
+        "yfinance": {
+            "PRICE_BATCH_SIZE": yf_constants.PRICE_BATCH_SIZE,
+            "PRICE_BATCH_MAX": yf_constants.PRICE_BATCH_MAX,
+            "THREADS_THRESHOLD": yf_constants.THREADS_THRESHOLD,
+            "PRICE_BATCH_SIZE_KEY": yf_constants.PRICE_BATCH_SIZE_KEY,
+            "DEFAULT_INTERVAL": yf_constants.DEFAULT_INTERVAL,
+            "DEFAULT_PRICE_PERIOD": yf_constants.DEFAULT_PRICE_PERIOD,
+        },
+        "sharadar": {
+            "MAX_ROWS_PER_REQUEST": sh_constants.MAX_ROWS_PER_REQUEST,
+            "DEFAULT_BATCH_SIZE": sh_constants.DEFAULT_BATCH_SIZE,
+            "MIN_BATCH_SIZE": sh_constants.MIN_BATCH_SIZE,
+            "TRADING_DAYS_RATIO": sh_constants.TRADING_DAYS_RATIO,
+            "QUARTERLY_DAYS_RATIO": sh_constants.QUARTERLY_DAYS_RATIO,
+            "PAGINATION_META_KEY": sh_constants.PAGINATION_META_KEY,
+            "PAGINATION_CURSOR_PARAM": sh_constants.PAGINATION_CURSOR_PARAM,
+            "MAX_PAGES": sh_constants.MAX_PAGES,
+        },
+    }
+
+
+__all__ = [
+    "get_provider_constants_preview",
+    "get_provider_datasets",
+    "get_provider_tables",
+]

--- a/packages/vertex-forager/src/vertex_forager/providers/yfinance/errors.py
+++ b/packages/vertex-forager/src/vertex_forager/providers/yfinance/errors.py
@@ -1,0 +1,19 @@
+"""YFinance-specific error helpers."""
+
+_REQUESTS_RETRYABLE_NAMES = frozenset(
+    {
+        "ConnectionError",
+        "Timeout",
+        "ConnectTimeout",
+        "ReadTimeout",
+    }
+)
+
+
+def is_retryable_yfinance_error(exc: Exception) -> bool:
+    """Return True for retryable transport errors surfaced by yfinance."""
+    exc_type = type(exc)
+    return exc_type.__module__ == "requests.exceptions" and exc_type.__name__ in _REQUESTS_RETRYABLE_NAMES
+
+
+__all__ = ["is_retryable_yfinance_error"]

--- a/packages/vertex-forager/src/vertex_forager/schema/registry.py
+++ b/packages/vertex-forager/src/vertex_forager/schema/registry.py
@@ -25,6 +25,15 @@ def _build_registry() -> _SchemaRegistry:
 
     provider_tables = get_provider_tables()
     provider_datasets = get_provider_datasets()
+    table_keys = set(provider_tables)
+    dataset_keys = set(provider_datasets)
+    if table_keys != dataset_keys:
+        missing_tables = sorted(dataset_keys - table_keys)
+        missing_datasets = sorted(table_keys - dataset_keys)
+        raise ValueError(
+            "Provider registry key mismatch: "
+            f"tables missing for {missing_tables}, datasets missing for {missing_datasets}"
+        )
     tables: dict[str, TableSchema] = {}
     for provider, table_map in provider_tables.items():
         duplicates = sorted(set(tables).intersection(table_map))

--- a/packages/vertex-forager/src/vertex_forager/schema/registry.py
+++ b/packages/vertex-forager/src/vertex_forager/schema/registry.py
@@ -21,19 +21,10 @@ class _SchemaRegistry:
 
 @lru_cache(maxsize=1)
 def _build_registry() -> _SchemaRegistry:
-    from vertex_forager.providers.sharadar.schema import DATASETS as SHARADAR_DATASETS
-    from vertex_forager.providers.sharadar.schema import TABLES as SHARADAR_TABLES
-    from vertex_forager.providers.yfinance.schema import DATASETS as YFINANCE_DATASETS
-    from vertex_forager.providers.yfinance.schema import TABLES as YFINANCE_TABLES
+    from vertex_forager.providers.catalog import get_provider_datasets, get_provider_tables
 
-    provider_tables = {
-        "sharadar": SHARADAR_TABLES,
-        "yfinance": YFINANCE_TABLES,
-    }
-    provider_datasets = {
-        "sharadar": SHARADAR_DATASETS,
-        "yfinance": YFINANCE_DATASETS,
-    }
+    provider_tables = get_provider_tables()
+    provider_datasets = get_provider_datasets()
     tables: dict[str, TableSchema] = {}
     for provider, table_map in provider_tables.items():
         duplicates = sorted(set(tables).intersection(table_map))

--- a/packages/vertex-forager/tests/unit/test_constants_view.py
+++ b/packages/vertex-forager/tests/unit/test_constants_view.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import pytest
+
+import vertex_forager.constants_view as constants_view
 from vertex_forager.constants_view import build_constants_preview
 
 
@@ -15,3 +18,14 @@ def test_build_constants_preview_all_includes_provider_sections(monkeypatch) -> 
     assert preview["yfinance"]["PRICE_BATCH_SIZE"] > 0
     assert preview["sharadar"]["MAX_ROWS_PER_REQUEST"] > 0
     assert preview["env_overrides"]["SHARADAR_API_KEY"] == "<redacted>"
+
+
+def test_build_constants_preview_global_does_not_import_provider_preview(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _fail() -> dict[str, dict[str, object]]:
+        raise AssertionError("provider preview should not be loaded for global-only section")
+
+    monkeypatch.setattr(constants_view, "get_provider_constants_preview", _fail)
+
+    preview = build_constants_preview("global")
+
+    assert set(preview) == {"global"}

--- a/packages/vertex-forager/tests/unit/test_constants_view.py
+++ b/packages/vertex-forager/tests/unit/test_constants_view.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from vertex_forager.constants_view import build_constants_preview
+
+
+def test_build_constants_preview_all_includes_provider_sections(monkeypatch) -> None:
+    monkeypatch.setenv("SHARADAR_API_KEY", "secret")
+
+    preview = build_constants_preview("all")
+
+    assert "global" in preview
+    assert "flow" in preview
+    assert "queue" in preview
+    assert "writers" in preview
+    assert preview["yfinance"]["PRICE_BATCH_SIZE"] > 0
+    assert preview["sharadar"]["MAX_ROWS_PER_REQUEST"] > 0
+    assert preview["env_overrides"]["SHARADAR_API_KEY"] == "<redacted>"

--- a/packages/vertex-forager/tests/unit/test_schema_registry.py
+++ b/packages/vertex-forager/tests/unit/test_schema_registry.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+
+import vertex_forager.providers.catalog as provider_catalog
+from vertex_forager.schema import registry as schema_registry
+
+
+def test_build_registry_rejects_provider_key_mismatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    schema_registry._build_registry.cache_clear()
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider_tables",
+        lambda: {"sharadar": MappingProxyType({})},
+    )
+    monkeypatch.setattr(
+        provider_catalog,
+        "get_provider_datasets",
+        lambda: {"yfinance": ()},
+    )
+
+    with pytest.raises(ValueError, match="Provider registry key mismatch"):
+        schema_registry._build_registry()
+
+    schema_registry._build_registry.cache_clear()

--- a/packages/vertex-forager/tests/unit/test_utils.py
+++ b/packages/vertex-forager/tests/unit/test_utils.py
@@ -373,6 +373,20 @@ def test_run_error_retryable_when_wrapped_timeout_error() -> None:
     assert err.retryable is True
 
 
+def test_run_error_retryable_for_wrapped_yfinance_requests_error() -> None:
+    RequestsTimeout = type("Timeout", (Exception,), {"__module__": "requests.exceptions"})
+
+    try:
+        try:
+            raise RequestsTimeout("yfinance timeout")
+        except Exception as exc:
+            raise FetchError("wrapped fetch failure") from exc
+    except FetchError as exc:
+        err = RunError.from_exception(exc, provider="yfinance", dataset="price", symbol="AAPL")
+
+    assert err.retryable is True
+
+
 def test_cleanup_dlq_tmp_default_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VERTEXFORAGER_ROOT", str(tmp_path / "app"))
     # create default dlq tmp under get_cache_dir()

--- a/packages/vertex-forager/tests/unit/test_utils.py
+++ b/packages/vertex-forager/tests/unit/test_utils.py
@@ -387,6 +387,20 @@ def test_run_error_retryable_for_wrapped_yfinance_requests_error() -> None:
     assert err.retryable is True
 
 
+def test_run_error_non_yfinance_does_not_use_yfinance_retry_rules() -> None:
+    RequestsTimeout = type("Timeout", (Exception,), {"__module__": "requests.exceptions"})
+
+    try:
+        try:
+            raise RequestsTimeout("provider-specific timeout")
+        except Exception as exc:
+            raise FetchError("wrapped fetch failure") from exc
+    except FetchError as exc:
+        err = RunError.from_exception(exc, provider="sharadar", dataset="price", symbol="AAPL")
+
+    assert err.retryable is False
+
+
 def test_cleanup_dlq_tmp_default_base(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("VERTEXFORAGER_ROOT", str(tmp_path / "app"))
     # create default dlq tmp under get_cache_dir()


### PR DESCRIPTION
## Summary

- Remove direct provider import edges from `schema/registry.py` and `constants_view.py` by centralizing built-in provider metadata in a provider catalog module.
- Keep the post-#459 closed-system architecture explicit while reducing cross-layer coupling.
- Fix the merge benchmark workflow so it does not fail when `profile_metrics.json` is intentionally absent after a skipped benchmark run.

## Linked Issue

- Closes #460

## Changes

- Add `packages/vertex-forager/src/vertex_forager/providers/catalog.py`
  - Centralize built-in provider table registry inputs.
  - Centralize built-in provider dataset registry inputs.
  - Centralize provider constants preview payloads used by the CLI.
- Update `packages/vertex-forager/src/vertex_forager/schema/registry.py`
  - Remove direct imports from provider schema modules.
  - Resolve provider tables/datasets via the catalog module instead.
- Update `packages/vertex-forager/src/vertex_forager/constants_view.py`
  - Remove direct imports from provider constants modules.
  - Source provider preview data from the catalog module instead.
- Add `packages/vertex-forager/tests/unit/test_constants_view.py`
  - Cover provider preview sections and env override redaction through the new path.
- Update `.github/workflows/ci.yml`
  - Add a benchmark artifact detection step.
  - Run benchmark compare only when `profile_metrics.json` exists.
  - Upload benchmark artifacts only when the metrics file exists.
  - Prevent non-blocking benchmark jobs from failing solely because the metrics artifact is absent.

## Verification

- Ran:
  - `uv run pytest packages/vertex-forager/tests/unit/test_constants_view.py packages/vertex-forager/tests/unit/test_sharadar_init_lazy_import.py packages/vertex-forager/tests/unit/test_core_qualitycheck.py -q`
  - `uv run pytest packages/ --cov-fail-under=80 -q`
  - `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
  - `uv run mypy packages/vertex-forager/src --strict`
  - `uv run python scripts/check_cycles.py`
- Results:
  - targeted tests: `20 passed`
  - full test suite: `521 passed`
  - ruff: pass
  - mypy: pass
  - import cycle check: pass

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * CI에서 벤치마크 메트릭 파일이 없을 때 비교/업로드 단계를 건너가도록 개선했습니다.

* **Refactor**
  * 공급자 카탈로그 도입 및 공급자별 상수 미리보기 호출을 지연해 구조와 일관성을 개선했습니다.
  * 공급자 테이블/데이터셋 키 일치 검증을 추가하고 재시도 판정 로직을 공급자별로 정리했습니다.

* **Tests**
  * 상수 미리보기, 스키마 레지스트리 키 불일치, 및 공급자별 재시도 동작에 대한 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->