### PR TITLE
test(vertex-forager): cover sweep and router gaps

### DIFF
--- a/packages/vertex-forager/tests/unit/test_core_sweep.py
+++ b/packages/vertex-forager/tests/unit/test_core_sweep.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from vertex_forager.core.sweep import _best_for_key, _score_run, build_sweep_combinations, score_and_rank_results
+
+
+def test_build_sweep_combinations_runs_all_products_when_sample_not_restrictive() -> None:
+    combos, message = build_sweep_combinations(
+        concurrency_list="1,2",
+        flush_rows_list="10",
+        keepalive_list="3",
+        connections_list="4,5",
+        timeout_list="6",
+        sample_count=None,
+        sample_seed=7,
+    )
+
+    assert len(combos) == 4
+    assert message == "Running all 4 combinations."
+    assert combos[0]["concurrency"] == 1
+    assert combos[-1]["limits"]["max_connections"] == 5
+
+
+def test_build_sweep_combinations_sampling_is_deterministic() -> None:
+    kwargs = {
+        "concurrency_list": "1,2,3",
+        "flush_rows_list": "10,20",
+        "keepalive_list": "4,5",
+        "connections_list": "6,7",
+        "timeout_list": "8",
+        "sample_count": 3,
+        "sample_seed": 123,
+    }
+
+    first, first_message = build_sweep_combinations(**kwargs)
+    second, second_message = build_sweep_combinations(**kwargs)
+
+    assert first == second
+    assert first_message == second_message
+    assert len(first) == 3
+    assert "Sampling 3 combinations from 24 total" in first_message
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "pattern"),
+    [
+        ("concurrency_list", "1,,2", "Invalid empty value"),
+        ("flush_rows_list", "-1", "must be positive"),
+    ],
+)
+def test_build_sweep_combinations_rejects_invalid_numeric_lists(
+    field: str,
+    value: str,
+    pattern: str,
+) -> None:
+    kwargs = {
+        "concurrency_list": None,
+        "flush_rows_list": None,
+        "keepalive_list": None,
+        "connections_list": None,
+        "timeout_list": None,
+        "sample_count": None,
+        "sample_seed": 1,
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValueError, match=pattern):
+        build_sweep_combinations(**kwargs)
+
+
+def test_score_run_uses_p95_and_error_penalty() -> None:
+    logger = logging.getLogger("test")
+    run = {
+        "measurements": {
+            "yfinance_price": {
+                "duration_s": 2.0,
+                "metrics": {
+                    "summary": {"http_duration_s_p95": 4.0},
+                    "errors": ["boom", "bang"],
+                },
+            }
+        }
+    }
+
+    score = _score_run(
+        run=run,
+        run_key="yfinance_price",
+        rank_by="duration_p95",
+        rank_alpha=0.5,
+        rank_error_penalty=3.0,
+        logger=logger,
+    )
+
+    assert score == 10.0
+
+
+def test_best_for_key_skips_error_entries_and_score_and_rank_populates_best() -> None:
+    logger = logging.getLogger("test")
+    results = {
+        "runs": [
+            {
+                "id": "bad",
+                "measurements": {
+                    "yfinance_price": {"error": "failed"},
+                    "yfinance_financials": {"error": "failed"},
+                },
+            },
+            {
+                "id": "slow",
+                "measurements": {
+                    "yfinance_price": {
+                        "duration_s": 3.0,
+                        "metrics": {"summary": {"http_duration_s_p95": 6.0}, "errors": []},
+                    },
+                    "yfinance_financials": {"error": "failed"},
+                },
+            },
+            {
+                "id": "best",
+                "measurements": {
+                    "yfinance_price": {
+                        "duration_s": 1.0,
+                        "metrics": {"summary": {"http_duration_s_p95": 2.0}, "errors": []},
+                    },
+                    "yfinance_financials": {"error": "failed"},
+                },
+            },
+        ]
+    }
+
+    best = _best_for_key(
+        results=results,
+        run_key="yfinance_price",
+        rank_by="duration_p95",
+        rank_alpha=0.25,
+        rank_error_penalty=5.0,
+        logger=logger,
+    )
+
+    ranked = score_and_rank_results(
+        results=results,
+        rank_by="duration_p95",
+        rank_alpha=0.25,
+        rank_error_penalty=5.0,
+        logger=logger,
+    )
+
+    assert best["id"] == "best"
+    assert ranked["best"]["yfinance_price"]["id"] == "best"
+    assert ranked["best"]["yfinance_financials"] == {}

--- a/packages/vertex-forager/tests/unit/test_persistence.py
+++ b/packages/vertex-forager/tests/unit/test_persistence.py
@@ -11,13 +11,19 @@ import pytest
 
 from vertex_forager.core.checkpoint import (
     Checkpoint,
+    cleanup_state_retention,
+    delete_checkpoints,
+    delete_dlq_entries,
     delete_dlq_entry,
+    delete_run_history,
     find_latest_checkpoint,
     get_cache_dir,
     get_state_db_path,
+    list_dlq_entries,
     list_pending_dlq_entries,
     list_run_history,
     load_checkpoint,
+    mark_dlq_retry_result,
     register_dlq_entry,
     save_checkpoint,
     save_run_history,
@@ -112,6 +118,51 @@ def test_save_and_load_checkpoint_with_pending_jobs() -> None:
         assert loaded.pending_jobs[0].spec.params["page"] == 2
 
 
+def test_delete_run_history_and_checkpoints_with_filters() -> None:
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        patch("vertex_forager.core.checkpoint.get_cache_dir", return_value=Path(tmpdir)),
+        patch("vertex_forager.core.checkpoint.time.time", side_effect=[100.0, 100.0, 200.0, 200.0]),
+    ):
+        save_checkpoint(Checkpoint(run_id="keep", provider="stub", dataset="prices", table_name="keep_table"))
+        save_checkpoint(Checkpoint(run_id="drop", provider="stub", dataset="prices", table_name="drop_table"))
+
+        save_run_history(
+            RunResult(
+                run_id="run-keep",
+                provider="stub",
+                dataset="prices",
+                table_name="keep_table",
+                total_rows=1,
+                errors=[],
+                quality_violations={},
+            ),
+            "run-keep",
+            table_name="keep_table",
+        )
+        save_run_history(
+            RunResult(
+                run_id="run-drop",
+                provider="stub",
+                dataset="prices",
+                table_name="drop_table",
+                total_rows=2,
+                errors=[],
+                quality_violations={},
+            ),
+            "run-drop",
+            table_name="drop_table",
+        )
+
+        assert delete_checkpoints(table_name="drop_table") == 1
+        assert find_latest_checkpoint(table_name="drop_table") is None
+        assert find_latest_checkpoint(table_name="keep_table") is not None
+
+        assert delete_run_history(table_name="drop_table") == 1
+        history = list_run_history(limit=10)
+        assert [entry["table_name"] for entry in history] == ["keep_table"]
+
+
 def test_find_latest_checkpoint_uses_sqlite_ordering() -> None:
     with (
         tempfile.TemporaryDirectory() as tmpdir,
@@ -126,6 +177,99 @@ def test_find_latest_checkpoint_uses_sqlite_ordering() -> None:
         latest = find_latest_checkpoint(table_name="stub_prices")
         assert latest is not None
         assert latest.run_id == "run_new"
+
+
+def test_mark_dlq_retry_result_and_delete_dlq_entries() -> None:
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        patch("vertex_forager.core.checkpoint.get_cache_dir", return_value=Path(tmpdir)),
+    ):
+        dlq_root = Path(tmpdir) / "dlq"
+        dlq_root.mkdir(parents=True, exist_ok=True)
+        payload_path = dlq_root / "failed" / "pkt.ipc"
+        payload_path.parent.mkdir(parents=True, exist_ok=True)
+        payload_path.write_bytes(b"payload")
+
+        register_dlq_entry(
+            path=payload_path,
+            table="yfinance_price",
+            provider="yfinance",
+            row_count=3,
+            output_uri="duckdb:///forager.duckdb",
+        )
+
+        mark_dlq_retry_result(path=payload_path.resolve(), success=False, error="still failing")
+        pending = list_dlq_entries(provider="yfinance", status="pending")
+        assert len(pending) == 1
+        assert pending[0]["retry_count"] == 1
+        assert pending[0]["last_error"] == "still failing"
+
+        mark_dlq_retry_result(path=payload_path.resolve(), success=True)
+        recovered = list_dlq_entries(provider="yfinance", status="recovered")
+        assert len(recovered) == 1
+        assert recovered[0]["retry_count"] == 2
+
+        deleted = delete_dlq_entries(provider="yfinance", status="recovered")
+        assert deleted == {"rows": 1, "files": 1}
+        assert not payload_path.exists()
+        assert list_dlq_entries(provider="yfinance", status=None) == []
+
+
+def test_cleanup_state_retention_removes_old_state() -> None:
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        patch("vertex_forager.core.checkpoint.get_cache_dir", return_value=Path(tmpdir)),
+    ):
+        with patch("vertex_forager.core.checkpoint.time.time", return_value=100.0):
+            save_checkpoint(
+                Checkpoint(
+                    run_id="old-run",
+                    provider="stub",
+                    dataset="prices",
+                    table_name="stub_prices",
+                    status="completed",
+                )
+            )
+        save_run_history(
+            RunResult(
+                run_id="old-run",
+                provider="stub",
+                dataset="prices",
+                table_name="stub_prices",
+                total_rows=1,
+                started_at=100.0,
+                finished_at=100.0,
+                errors=[],
+                quality_violations={},
+            ),
+            "old-run",
+            table_name="stub_prices",
+        )
+
+        dlq_root = Path(tmpdir) / "dlq"
+        dlq_root.mkdir(parents=True, exist_ok=True)
+        payload_path = dlq_root / "stale.ipc"
+        payload_path.write_bytes(b"payload")
+        with patch("vertex_forager.core.checkpoint.time.time", return_value=100.0):
+            register_dlq_entry(
+                path=payload_path,
+                table="stub_prices",
+                provider="stub",
+                row_count=1,
+                output_uri=None,
+            )
+
+        with patch("vertex_forager.core.checkpoint.time.time", return_value=5000.0):
+            result = cleanup_state_retention(
+                checkpoint_retention_days=0,
+                run_history_retention_days=0,
+                dlq_retention_s=0,
+            )
+
+        assert result == {"checkpoints": 1, "runs": 1, "dlq_rows": 1, "dlq_files": 1}
+        assert find_latest_checkpoint(table_name="stub_prices") is None
+        assert list_run_history(limit=10) == []
+        assert list_dlq_entries(status=None) == []
 
 
 def test_initialize_schema_marks_legacy_in_progress_checkpoints_completed() -> None:

--- a/packages/vertex-forager/tests/unit/test_router.py
+++ b/packages/vertex-forager/tests/unit/test_router.py
@@ -200,6 +200,27 @@ class TestSharadarRouterUnit:
         with pytest.raises(ValueError, match="Invalid symbol"):
             router._build_per_symbol_job(dataset="price", symbol="   ")
 
+    def test_should_paginate_without_symbols_only_for_supported_datasets(
+        self,
+        router: SharadarRouter,
+    ) -> None:
+        assert router._should_paginate_without_symbols(dataset="tickers", symbols=None) is True
+        assert router._should_paginate_without_symbols(dataset="sp500", symbols=None) is True
+        assert router._should_paginate_without_symbols(dataset="price", symbols=None) is False
+        assert router._should_paginate_without_symbols(dataset="tickers", symbols=["AAPL"]) is False
+
+    def test_resolve_dimension_and_per_page_apply_defaults_and_clamps(
+        self,
+        router: SharadarRouter,
+    ) -> None:
+        assert router._resolve_dimension(None) == "MRT"
+        assert router._resolve_dimension("   ") == "MRT"
+        assert router._resolve_dimension("ARQ") == "ARQ"
+
+        assert router._resolve_per_page("invalid") == MAX_ROWS_PER_REQUEST
+        assert router._resolve_per_page(MAX_ROWS_PER_REQUEST * 5) == MAX_ROWS_PER_REQUEST
+        assert router._resolve_per_page(0) == 1
+
     @pytest.mark.asyncio
     async def test_generate_jobs_does_not_batch_by_default(
         self, router: SharadarRouter

--- a/packages/vertex-forager/tests/unit/test_yfinance_router.py
+++ b/packages/vertex-forager/tests/unit/test_yfinance_router.py
@@ -12,6 +12,7 @@ import pytest
 
 from vertex_forager.core.config import FetchJob, ParseResult, RequestSpec
 from vertex_forager.exceptions import TransformError
+from vertex_forager.providers.yfinance.constants import PRICE_BATCH_MAX
 
 if TYPE_CHECKING:
     from vertex_forager.providers.yfinance.router import YFinanceRouter
@@ -20,9 +21,11 @@ try:
     import pandas as pd
 
     from vertex_forager.providers.yfinance.router import YFinanceRouter as _YFinanceRouter
+    from vertex_forager.providers.yfinance.router import _normalize_pickle_compat_datasets
 except ImportError as err:
     if err.name in {"pandas", "yfinance"}:
         pd = None
+        _normalize_pickle_compat_datasets = None
         _YFinanceRouter = None
     else:
         raise
@@ -179,6 +182,21 @@ class TestYFinanceRouterUnit:
         with pytest.raises(TransformError):
             _ = router.parse(job=job, payload=payload)
 
+    def test_normalize_pickle_compat_datasets_dedups_and_drops_blanks(self) -> None:
+        assert _normalize_pickle_compat_datasets(["price", " price ", "", "financials", "price"]) == (
+            "price",
+            "financials",
+        )
+
+    def test_router_clamps_price_batch_size_and_coerces_invalid_values(self) -> None:
+        default_router = YFinanceRouter(rate_limit=60, price_batch_size="bad")
+        max_router = YFinanceRouter(rate_limit=60, price_batch_size=10_000)
+        min_router = YFinanceRouter(rate_limit=60, price_batch_size=0)
+
+        assert default_router._price_batch_size == default_router.PRICE_BATCH_SIZE
+        assert max_router._price_batch_size == PRICE_BATCH_MAX
+        assert min_router._price_batch_size == 1
+
     def test_pickle_compat_env_vars_no_longer_enable_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("VF_ALLOW_PICKLE_COMPAT", "1")
         monkeypatch.setenv("VF_PICKLE_ALLOWED_DATASETS", "price")
@@ -261,6 +279,32 @@ class TestYFinanceRouterUnit:
         assert frame.get_column("period").to_list() == ["0m", "-1m", "-2m"]
         assert "strongbuy" in frame.columns
         assert frame.get_column("strongbuy").to_list() == [5, 3, 2]
+
+    def test_typed_job_context_coerces_attempt_and_ignores_invalid_values(
+        self,
+        yfinance_router: YFinanceRouter,
+    ) -> None:
+        valid_job = FetchJob(
+            provider="yfinance",
+            dataset="price",
+            symbol="AAPL",
+            spec=RequestSpec(url="yfinance://AAPL", params={"dataset": "price"}),
+            context={"symbol": "AAPL", "attempt": "2", "is_batch": True},
+        )
+        invalid_job = FetchJob(
+            provider="yfinance",
+            dataset="price",
+            symbol="AAPL",
+            spec=RequestSpec(url="yfinance://AAPL", params={"dataset": "price"}),
+            context={"symbol": 123, "attempt": "abc", "is_batch": "yes"},
+        )
+
+        assert yfinance_router._typed_job_context(job=valid_job) == {
+            "symbol": "AAPL",
+            "attempt": 2,
+            "is_batch": True,
+        }
+        assert yfinance_router._typed_job_context(job=invalid_job) == {"attempt": None}
 
     def test_parse_price_ipc_with_secure_router(
         self, yfinance_router: YFinanceRouter, yf_price_df: pd.DataFrame


### PR DESCRIPTION
## Summary

- Add targeted unit coverage for `core.sweep` ranking and sampling logic.
- Expand checkpoint persistence coverage for delete, DLQ retry, and retention flows.
- Fill missing YFinance and Sharadar router edge-case tests around batching, normalization, and context coercion.

## Linked Issue

- Closes #463

## Changes

- Add `packages/vertex-forager/tests/unit/test_core_sweep.py`
  - Cover `build_sweep_combinations()` full-product and deterministic sampling behavior.
  - Cover invalid numeric list parsing.
  - Cover `_score_run()`, `_best_for_key()`, and `score_and_rank_results()` ranking behavior.
- Update `packages/vertex-forager/tests/unit/test_persistence.py`
  - Add coverage for `delete_run_history()` and `delete_checkpoints()` filter behavior.
  - Add coverage for `mark_dlq_retry_result()` and `delete_dlq_entries()`.
  - Add coverage for `cleanup_state_retention()`.
- Update `packages/vertex-forager/tests/unit/test_yfinance_router.py`
  - Add coverage for `_normalize_pickle_compat_datasets()`.
  - Add coverage for `price_batch_size` coercion/clamping.
  - Add coverage for `_typed_job_context()` coercion behavior.
- Update `packages/vertex-forager/tests/unit/test_router.py`
  - Add coverage for Sharadar pagination-without-symbols rules.
  - Add coverage for `_resolve_dimension()` defaults.
  - Add coverage for `_resolve_per_page()` clamp/default behavior.

## Verification

- Ran:
  - `uv run pytest packages/vertex-forager/tests/unit/test_core_sweep.py packages/vertex-forager/tests/unit/test_persistence.py packages/vertex-forager/tests/unit/test_yfinance_router.py packages/vertex-forager/tests/unit/test_router.py -q`
  - `uv run pytest packages/ --cov-fail-under=80 -q`
  - `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
  - `uv run mypy packages/vertex-forager/src --strict`
  - `uv run python scripts/check_cycles.py`
- Results:
  - targeted unit tests: `70 passed`
  - full test suite: `539 passed`
  - ruff: pass
  - mypy: pass
  - import cycle check: pass

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 핵심 스윕 기능에 대한 단위 테스트 추가
  * 영속성 API 작업 검증 테스트 추가
  * 라우터 및 데이터 소스 통합 기능에 대한 테스트 커버리지 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->