### PR TITLE
perf(vertex-forager): reuse checkpoint sqlite connection

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/checkpoint.py
+++ b/packages/vertex-forager/src/vertex_forager/core/checkpoint.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from contextlib import closing
+from collections.abc import Iterator
+from contextlib import closing, contextmanager
 import json
 import os
 from pathlib import Path
@@ -66,6 +67,20 @@ def _connect_state_db() -> sqlite3.Connection:
     conn.row_factory = sqlite3.Row
     _initialize_schema(conn)
     return conn
+
+
+def open_state_db() -> sqlite3.Connection:
+    """Open a reusable SQLite state connection with schema initialized once."""
+    return _connect_state_db()
+
+
+@contextmanager
+def _use_state_db(conn: sqlite3.Connection | None = None) -> Iterator[sqlite3.Connection]:
+    if conn is not None:
+        yield conn
+        return
+    with closing(_connect_state_db()) as local_conn:
+        yield local_conn
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -362,15 +377,15 @@ def _migrate_run_history_table(conn: sqlite3.Connection) -> None:
     conn.execute("RELEASE SAVEPOINT migrate_run_history")
 
 
-def save_checkpoint(checkpoint: Checkpoint) -> None:
+def save_checkpoint(checkpoint: Checkpoint, *, conn: sqlite3.Connection | None = None) -> None:
     """Save checkpoint state to SQLite.
 
     Args:
         checkpoint: Checkpoint data to save.
     """
     now = time.time()
-    with closing(_connect_state_db()) as conn:
-        conn.execute(
+    with _use_state_db(conn) as db_conn:  # type: sqlite3.Connection
+        db_conn.execute(
             """
             INSERT INTO checkpoints (
                 run_id,
@@ -411,10 +426,10 @@ def save_checkpoint(checkpoint: Checkpoint) -> None:
                 now,
             ),
         )
-        conn.commit()
+        db_conn.commit()
 
 
-def load_checkpoint(run_id: str) -> Checkpoint | None:
+def load_checkpoint(run_id: str, *, conn: sqlite3.Connection | None = None) -> Checkpoint | None:
     """Load checkpoint state from SQLite.
 
     Args:
@@ -423,8 +438,8 @@ def load_checkpoint(run_id: str) -> Checkpoint | None:
     Returns:
         Checkpoint if present and valid, otherwise None.
     """
-    with closing(_connect_state_db()) as conn:
-        row = conn.execute(
+    with _use_state_db(conn) as db_conn:  # type: sqlite3.Connection
+        row = db_conn.execute(
             """
             SELECT
                 run_id,
@@ -468,6 +483,7 @@ def find_latest_checkpoint(
     dataset: str | None = None,
     *,
     table_name: str | None = None,
+    conn: sqlite3.Connection | None = None,
 ) -> Checkpoint | None:
     """Find the latest checkpoint by table name or by provider and dataset."""
     query = """
@@ -485,8 +501,8 @@ def find_latest_checkpoint(
     else:
         raise ValueError("find_latest_checkpoint requires table_name or provider+dataset")
     query += " ORDER BY updated_at DESC, rowid DESC LIMIT 1"
-    with closing(_connect_state_db()) as conn:
-        row = conn.execute(query, tuple(params)).fetchone()
+    with _use_state_db(conn) as db_conn:  # type: sqlite3.Connection
+        row = db_conn.execute(query, tuple(params)).fetchone()
     if row is None:
         return None
     try:
@@ -671,7 +687,7 @@ def delete_completed_checkpoints_before(before_ts: float) -> int:
         return int(cursor.rowcount)
 
 
-def delete_checkpoints(*, table_name: str | None = None) -> int:
+def delete_checkpoints(*, table_name: str | None = None, conn: sqlite3.Connection | None = None) -> int:
     """Delete checkpoints scoped to an optional table name."""
     query = "DELETE FROM checkpoints"
     clauses: list[str] = []
@@ -681,9 +697,9 @@ def delete_checkpoints(*, table_name: str | None = None) -> int:
         params.append(table_name)
     if clauses:
         query += " WHERE " + " AND ".join(clauses)
-    with closing(_connect_state_db()) as conn:
-        cursor = conn.execute(query, tuple(params))
-        conn.commit()
+    with _use_state_db(conn) as db_conn:  # type: sqlite3.Connection
+        cursor = db_conn.execute(query, tuple(params))
+        db_conn.commit()
         return int(cursor.rowcount)
 
 

--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -995,6 +995,8 @@ class VertexForager:
             logger.debug("PIPELINE: Run history saved for run %s", run_id)
         except Exception as e:
             logger.warning("PIPELINE: Failed to save run history: %s", e)
+        finally:
+            self._checkpoint_tracker.close()
 
     def _merge_component_counters(self) -> None:
         self._run_finalizer.merge_component_counters()
@@ -1053,6 +1055,7 @@ class VertexForager:
                 exceptions from tasks are logged and suppressed via ``return_exceptions=True``.
         """
         if not self._active_tasks:
+            self._checkpoint_tracker.close()
             return
 
         logger.debug("PIPELINE: Stopping pipeline...")
@@ -1086,6 +1089,7 @@ class VertexForager:
             logger.exception("PIPELINE: Parse executor shutdown failed: %s", e)
         except Exception:
             logger.exception("PIPELINE: Unexpected error during parse executor shutdown")
+        self._checkpoint_tracker.close()
         logger.debug("PIPELINE: Pipeline stopped.")
 
     async def _cancel_non_writer_tasks(self, writer_set: set[asyncio.Task[Any]]) -> None:

--- a/packages/vertex-forager/src/vertex_forager/core/runtime_state.py
+++ b/packages/vertex-forager/src/vertex_forager/core/runtime_state.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Sequence
+from contextlib import suppress
+import sqlite3
 from typing import Literal, Protocol
 
-from vertex_forager.core.checkpoint import Checkpoint, delete_checkpoints, find_latest_checkpoint, save_checkpoint
+from vertex_forager.core.checkpoint import (
+    Checkpoint,
+    delete_checkpoints,
+    find_latest_checkpoint,
+    open_state_db,
+    save_checkpoint,
+)
 from vertex_forager.core.domain import FetchJob
 from vertex_forager.writers.memory import InMemoryBufferWriter
 
@@ -66,9 +74,17 @@ class CheckpointTracker:
         self._save_every = max(1, int(save_every))
         self._save_attempts = 0
         self._lock = asyncio.Lock()
+        self._conn: sqlite3.Connection | None = None
+
+    def _connection(self) -> sqlite3.Connection | None:
+        if isinstance(self._writer, InMemoryBufferWriter):
+            return None
+        if self._conn is None:
+            self._conn = open_state_db()
+        return self._conn
 
     def find_latest(self, provider: str, dataset: str) -> Checkpoint | None:
-        return find_latest_checkpoint(provider, dataset)
+        return find_latest_checkpoint(provider, dataset, conn=self._connection())
 
     def save(
         self,
@@ -83,7 +99,8 @@ class CheckpointTracker:
         status: Literal["in_progress", "completed"] = "in_progress",
         force: bool = False,
     ) -> bool:
-        if isinstance(self._writer, InMemoryBufferWriter):
+        conn = self._connection()
+        if conn is None:
             return False
         if not completed_symbols and not failed_symbols and not pending_jobs:
             return False
@@ -103,7 +120,7 @@ class CheckpointTracker:
             status=status,
         )
         try:
-            save_checkpoint(checkpoint)
+            save_checkpoint(checkpoint, conn=conn)
             self._logger.debug("PIPELINE: Checkpoint updated for run %s", run_id)
             return True
         except Exception as exc:
@@ -139,9 +156,17 @@ class CheckpointTracker:
 
     def clear(self, *, table_name: str | None = None) -> int:
         self._save_attempts = 0
-        if isinstance(self._writer, InMemoryBufferWriter):
+        conn = self._connection()
+        if conn is None:
             return 0
-        return delete_checkpoints(table_name=table_name)
+        return delete_checkpoints(table_name=table_name, conn=conn)
+
+    def close(self) -> None:
+        if self._conn is None:
+            return
+        with suppress(Exception):
+            self._conn.close()
+        self._conn = None
 
 
 __all__ = ["CheckpointTracker", "PendingJobRegistry"]

--- a/packages/vertex-forager/src/vertex_forager/core/runtime_state.py
+++ b/packages/vertex-forager/src/vertex_forager/core/runtime_state.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Callable, Sequence
 from contextlib import suppress
 import sqlite3
+import threading
 from typing import Literal, Protocol
 
 from vertex_forager.core.checkpoint import (
@@ -74,14 +75,18 @@ class CheckpointTracker:
         self._save_every = max(1, int(save_every))
         self._save_attempts = 0
         self._lock = asyncio.Lock()
+        self._conn_lock = threading.Lock()
         self._conn: sqlite3.Connection | None = None
 
     def _connection(self) -> sqlite3.Connection | None:
         if isinstance(self._writer, InMemoryBufferWriter):
             return None
-        if self._conn is None:
-            self._conn = open_state_db()
-        return self._conn
+        if self._conn is not None:
+            return self._conn
+        with self._conn_lock:
+            if self._conn is None:
+                self._conn = open_state_db()
+            return self._conn
 
     def find_latest(self, provider: str, dataset: str) -> Checkpoint | None:
         return find_latest_checkpoint(provider, dataset, conn=self._connection())
@@ -162,11 +167,13 @@ class CheckpointTracker:
         return delete_checkpoints(table_name=table_name, conn=conn)
 
     def close(self) -> None:
-        if self._conn is None:
+        with self._conn_lock:
+            conn = self._conn
+            self._conn = None
+        if conn is None:
             return
         with suppress(Exception):
-            self._conn.close()
-        self._conn = None
+            conn.close()
 
 
 __all__ = ["CheckpointTracker", "PendingJobRegistry"]

--- a/packages/vertex-forager/tests/unit/test_checkpoint_tracker.py
+++ b/packages/vertex-forager/tests/unit/test_checkpoint_tracker.py
@@ -56,8 +56,11 @@ def test_checkpoint_tracker_save_and_find_latest_roundtrip() -> None:
 def test_checkpoint_tracker_frequency_policy_and_clear() -> None:
     saves: list[object] = []
 
+    def _record_save(*args: object, **kwargs: object) -> None:
+        saves.append((args, kwargs))
+
     with (
-        patch("vertex_forager.core.runtime_state.save_checkpoint", side_effect=saves.append),
+        patch("vertex_forager.core.runtime_state.save_checkpoint", side_effect=_record_save),
         patch("vertex_forager.core.runtime_state.delete_checkpoints", return_value=3) as delete_mock,
     ):
         tracker = CheckpointTracker(
@@ -82,7 +85,9 @@ def test_checkpoint_tracker_frequency_policy_and_clear() -> None:
         assert saves == []
 
         assert tracker.clear(table_name="stub_price") == 3
-        delete_mock.assert_called_once_with(table_name="stub_price")
+        delete_mock.assert_called_once()
+        assert delete_mock.call_args.kwargs["table_name"] == "stub_price"
+        assert delete_mock.call_args.kwargs["conn"] is not None
 
         assert (
             tracker.save(
@@ -109,3 +114,41 @@ def test_checkpoint_tracker_frequency_policy_and_clear() -> None:
             is True
         )
         assert len(saves) == 1
+
+
+def test_checkpoint_tracker_reuses_single_state_connection() -> None:
+    with (
+        tempfile.TemporaryDirectory() as tmpdir,
+        patch("vertex_forager.core.checkpoint.get_cache_dir", return_value=Path(tmpdir)),
+    ):
+        import vertex_forager.core.checkpoint as checkpoint_mod
+
+        opened = 0
+        original_open = checkpoint_mod.open_state_db
+
+        def _open_once() -> object:
+            nonlocal opened
+            opened += 1
+            return original_open()
+
+        with patch("vertex_forager.core.runtime_state.open_state_db", side_effect=_open_once):
+            tracker = CheckpointTracker(
+                writer=object(),
+                requested_symbols_getter=lambda: ["AAPL"],
+                logger=_Logger(),
+            )
+
+            assert tracker.save(
+                run_id="run-1",
+                provider="stub",
+                dataset="price",
+                table_name="stub_price",
+                completed_symbols={"AAPL"},
+                failed_symbols=set(),
+                pending_jobs=[_job()],
+            )
+            assert tracker.find_latest("stub", "price") is not None
+            assert tracker.clear(table_name="stub_price") == 1
+            assert opened == 1
+
+            tracker.close()

--- a/packages/vertex-forager/tests/unit/test_checkpoint_tracker.py
+++ b/packages/vertex-forager/tests/unit/test_checkpoint_tracker.py
@@ -62,6 +62,7 @@ def test_checkpoint_tracker_frequency_policy_and_clear() -> None:
     with (
         patch("vertex_forager.core.runtime_state.save_checkpoint", side_effect=_record_save),
         patch("vertex_forager.core.runtime_state.delete_checkpoints", return_value=3) as delete_mock,
+        patch("vertex_forager.core.runtime_state.open_state_db", return_value=object()),
     ):
         tracker = CheckpointTracker(
             writer=object(),


### PR DESCRIPTION
## Summary

- Reuse a single SQLite state connection across checkpoint operations instead of reconnecting on each save/find/clear call.
- Reduce checkpoint persistence overhead in the pipeline hot path while keeping checkpoint behavior unchanged.

## Linked Issue

- Closes #457

## Changes

- Add reusable state DB connection helpers in `packages/vertex-forager/src/vertex_forager/core/checkpoint.py`
- Update `save_checkpoint()`, `load_checkpoint()`, `find_latest_checkpoint()`, and `delete_checkpoints()` to accept an optional shared SQLite connection
- Update `packages/vertex-forager/src/vertex_forager/core/runtime_state.py` so `CheckpointTracker` lazily opens, reuses, and closes a single SQLite connection for checkpoint operations
- Update `packages/vertex-forager/src/vertex_forager/core/pipeline.py` to close the tracker-owned connection on normal run completion and stop paths
- Add regression coverage in `packages/vertex-forager/tests/unit/test_checkpoint_tracker.py` to verify repeated save/find/clear calls reuse one state connection

## Verification

- Ran `uv run pytest packages/vertex-forager/tests/unit/test_checkpoint_tracker.py packages/vertex-forager/tests/unit/test_pipeline_coverage.py packages/vertex-forager/tests/unit/test_state_manager.py -q`
- Ran `uv run pytest packages/ --cov-fail-under=80 -q`
- Ran `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
- Ran `uv run mypy packages/vertex-forager/src --strict`
- Ran `uv run python scripts/check_cycles.py`
- Verified results: `59 passed` for targeted tests, `545 passed` for full test suite, `ruff` pass, `mypy` pass, import cycle check pass

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **최적화**
  * 체크포인트 저장소의 데이터베이스 연결을 선택적으로 재사용하도록 개선해 리소스 효율성을 높였습니다.
* **버그 수정**
  * 종료 및 중단 흐름에서 체크포인트 추적기의 정리(cleanup)가 항상 수행되도록 안정성을 강화했습니다.
* **테스트**
  * 연결 재사용 동작과 단일 연결 유지 여부를 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->