### PR TITLE
perf(vertex-forager): rate limit progress emit

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -1385,6 +1385,8 @@ class VertexForager:
         self._progress.record_terminal(terminal_count)
         if progress_bar is None and on_progress is None:
             return
+        if not self._progress.should_emit(finished=finished):
+            return
         if result is None:
             result = RunResult(provider=self._router.provider, dataset=None)
         if result_lock is None:

--- a/packages/vertex-forager/src/vertex_forager/core/progress.py
+++ b/packages/vertex-forager/src/vertex_forager/core/progress.py
@@ -12,6 +12,8 @@ from tqdm import tqdm
 
 from vertex_forager.core.config import ProgressSnapshot
 
+PROGRESS_EMIT_INTERVAL_S = 0.1
+
 
 def compute_window_start(
     *, progress_started_at: float, progress_history: deque[tuple[float, int]], now: float
@@ -48,6 +50,7 @@ class ProgressEmitter:
         self._display_done = 0
         self._counters: dict[str, int] = {}
         self._process: psutil.Process | None = None
+        self._last_emit_at = 0.0
 
     def reset(self, *, jobs_total: int | None, jobs_done_initial: int = 0) -> None:
         self._started_at = time.monotonic()
@@ -59,6 +62,7 @@ class ProgressEmitter:
         self._display_done = jobs_done_initial
         self._counters = {}
         self._process = None
+        self._last_emit_at = 0.0
 
     def _ensure_process_initialized(self) -> psutil.Process:
         if self._process is None:
@@ -148,6 +152,10 @@ class ProgressEmitter:
         dataset: str,
         logger: Any,
     ) -> None:
+        now = time.monotonic()
+        if not snapshot.finished and self._last_emit_at and now - self._last_emit_at < PROGRESS_EMIT_INTERVAL_S:
+            return
+        self._last_emit_at = now
         if progress_bar is not None:
             delta = max(0, snapshot.jobs_done - self._display_done)
             if delta:

--- a/packages/vertex-forager/src/vertex_forager/core/progress.py
+++ b/packages/vertex-forager/src/vertex_forager/core/progress.py
@@ -143,8 +143,10 @@ class ProgressEmitter:
 
     def should_emit(self, *, finished: bool) -> bool:
         now = time.monotonic()
-        if not finished and self._last_emit_at and now - self._last_emit_at < PROGRESS_EMIT_INTERVAL_S:
-            return False
+        if not finished:
+            if self._last_emit_at and now - self._last_emit_at < PROGRESS_EMIT_INTERVAL_S:
+                return False
+            self._last_emit_at = now
         return True
 
     async def emit(
@@ -158,7 +160,6 @@ class ProgressEmitter:
         dataset: str,
         logger: Any,
     ) -> None:
-        self._last_emit_at = time.monotonic()
         if progress_bar is not None:
             delta = max(0, snapshot.jobs_done - self._display_done)
             if delta:

--- a/packages/vertex-forager/src/vertex_forager/core/progress.py
+++ b/packages/vertex-forager/src/vertex_forager/core/progress.py
@@ -141,6 +141,12 @@ class ProgressEmitter:
             finished=finished,
         )
 
+    def should_emit(self, *, finished: bool) -> bool:
+        now = time.monotonic()
+        if not finished and self._last_emit_at and now - self._last_emit_at < PROGRESS_EMIT_INTERVAL_S:
+            return False
+        return True
+
     async def emit(
         self,
         *,
@@ -152,10 +158,7 @@ class ProgressEmitter:
         dataset: str,
         logger: Any,
     ) -> None:
-        now = time.monotonic()
-        if not snapshot.finished and self._last_emit_at and now - self._last_emit_at < PROGRESS_EMIT_INTERVAL_S:
-            return
-        self._last_emit_at = now
+        self._last_emit_at = time.monotonic()
         if progress_bar is not None:
             delta = max(0, snapshot.jobs_done - self._display_done)
             if delta:

--- a/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
+++ b/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
@@ -587,6 +587,33 @@ async def test_emit_progress_short_circuits_without_consumers_when_finished() ->
 
 
 @pytest.mark.asyncio
+async def test_emit_progress_skips_snapshot_build_when_rate_limited() -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+    engine._progress.reset(jobs_total=1)
+
+    def _boom(**_: object) -> object:
+        raise AssertionError("build_snapshot should not be called when emission is rate-limited")
+
+    engine._progress.build_snapshot = _boom  # type: ignore[method-assign]
+    engine._progress.should_emit = lambda *, finished: False  # type: ignore[method-assign]
+
+    await engine._emit_progress(
+        result=RunResult(provider="stub", dataset="d"),
+        result_lock=asyncio.Lock(),
+        on_progress=lambda snapshot: None,
+        progress_bar=None,
+        terminal_count=1,
+        finished=False,
+        show_summary=False,
+        summary_dataset="d",
+    )
+
+    assert engine._progress._jobs_done == 1
+    assert engine._progress._window_events == 1
+
+
+@pytest.mark.asyncio
 async def test_progress_snapshot_uses_retained_sample_window_for_throughput(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/vertex-forager/tests/unit/test_progress_emitter.py
+++ b/packages/vertex-forager/tests/unit/test_progress_emitter.py
@@ -121,7 +121,8 @@ def test_should_emit_rate_limits_non_finished_snapshots_but_allows_finished(
     fake_now = {"value": 100.0}
     monkeypatch.setattr("vertex_forager.core.progress.time.monotonic", lambda: fake_now["value"])
     assert emitter.should_emit(finished=False) is True
-    emitter._last_emit_at = 100.0
+    assert emitter._last_emit_at == 100.0
+    assert emitter.should_emit(finished=False) is False
     fake_now["value"] = 100.05
     assert emitter.should_emit(finished=False) is False
     assert emitter.should_emit(finished=True) is True

--- a/packages/vertex-forager/tests/unit/test_progress_emitter.py
+++ b/packages/vertex-forager/tests/unit/test_progress_emitter.py
@@ -110,8 +110,7 @@ async def test_emit_invokes_callback_and_progress_bar() -> None:
     logger.error.assert_not_called()
 
 
-@pytest.mark.asyncio
-async def test_emit_rate_limits_non_finished_snapshots_but_allows_finished(
+def test_should_emit_rate_limits_non_finished_snapshots_but_allows_finished(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     proc = _Proc()
@@ -121,65 +120,10 @@ async def test_emit_rate_limits_non_finished_snapshots_but_allows_finished(
 
     fake_now = {"value": 100.0}
     monkeypatch.setattr("vertex_forager.core.progress.time.monotonic", lambda: fake_now["value"])
-
-    seen: list[object] = []
-
-    async def on_progress(progress_snapshot: object) -> None:
-        seen.append(progress_snapshot)
-
-    logger = MagicMock()
-
-    snapshot_a = emitter.build_snapshot(
-        pending_jobs=1,
-        errors=0,
-        retries=0,
-        throttle_events=0,
-        finished=False,
-    )
+    assert emitter.should_emit(finished=False) is True
+    emitter._last_emit_at = 100.0
     fake_now["value"] = 100.05
-    snapshot_b = emitter.build_snapshot(
-        pending_jobs=1,
-        errors=0,
-        retries=0,
-        throttle_events=0,
-        finished=False,
-    )
+    assert emitter.should_emit(finished=False) is False
+    assert emitter.should_emit(finished=True) is True
     fake_now["value"] = 100.20
-    snapshot_c = emitter.build_snapshot(
-        pending_jobs=0,
-        errors=0,
-        retries=0,
-        throttle_events=0,
-        finished=True,
-        result_duration_s=1.0,
-    )
-
-    await emitter.emit(
-        snapshot=snapshot_a,
-        on_progress=on_progress,
-        progress_bar=None,
-        show_summary=False,
-        provider="stub",
-        dataset="price",
-        logger=logger,
-    )
-    await emitter.emit(
-        snapshot=snapshot_b,
-        on_progress=on_progress,
-        progress_bar=None,
-        show_summary=False,
-        provider="stub",
-        dataset="price",
-        logger=logger,
-    )
-    await emitter.emit(
-        snapshot=snapshot_c,
-        on_progress=on_progress,
-        progress_bar=None,
-        show_summary=False,
-        provider="stub",
-        dataset="price",
-        logger=logger,
-    )
-
-    assert seen == [snapshot_a, snapshot_c]
+    assert emitter.should_emit(finished=False) is True

--- a/packages/vertex-forager/tests/unit/test_progress_emitter.py
+++ b/packages/vertex-forager/tests/unit/test_progress_emitter.py
@@ -108,3 +108,78 @@ async def test_emit_invokes_callback_and_progress_bar() -> None:
     progress_bar.set_postfix.assert_called_once()
     progress_bar.close.assert_called_once()
     logger.error.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_emit_rate_limits_non_finished_snapshots_but_allows_finished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    proc = _Proc()
+    with patch("vertex_forager.core.progress.psutil.Process", return_value=proc):
+        emitter = ProgressEmitter()
+        emitter.reset(jobs_total=5)
+
+    fake_now = {"value": 100.0}
+    monkeypatch.setattr("vertex_forager.core.progress.time.monotonic", lambda: fake_now["value"])
+
+    seen: list[object] = []
+
+    async def on_progress(progress_snapshot: object) -> None:
+        seen.append(progress_snapshot)
+
+    logger = MagicMock()
+
+    snapshot_a = emitter.build_snapshot(
+        pending_jobs=1,
+        errors=0,
+        retries=0,
+        throttle_events=0,
+        finished=False,
+    )
+    fake_now["value"] = 100.05
+    snapshot_b = emitter.build_snapshot(
+        pending_jobs=1,
+        errors=0,
+        retries=0,
+        throttle_events=0,
+        finished=False,
+    )
+    fake_now["value"] = 100.20
+    snapshot_c = emitter.build_snapshot(
+        pending_jobs=0,
+        errors=0,
+        retries=0,
+        throttle_events=0,
+        finished=True,
+        result_duration_s=1.0,
+    )
+
+    await emitter.emit(
+        snapshot=snapshot_a,
+        on_progress=on_progress,
+        progress_bar=None,
+        show_summary=False,
+        provider="stub",
+        dataset="price",
+        logger=logger,
+    )
+    await emitter.emit(
+        snapshot=snapshot_b,
+        on_progress=on_progress,
+        progress_bar=None,
+        show_summary=False,
+        provider="stub",
+        dataset="price",
+        logger=logger,
+    )
+    await emitter.emit(
+        snapshot=snapshot_c,
+        on_progress=on_progress,
+        progress_bar=None,
+        show_summary=False,
+        provider="stub",
+        dataset="price",
+        logger=logger,
+    )
+
+    assert seen == [snapshot_a, snapshot_c]


### PR DESCRIPTION
## Summary

- Rate-limit human-facing progress emission so progress callbacks and tqdm updates do not run on every job completion in the pipeline hot path.
- Reduce progress emission overhead while preserving final progress delivery and the existing snapshot shape.

## Linked Issue

- Closes #479

## Changes

- Add a default progress emit interval in `packages/vertex-forager/src/vertex_forager/core/progress.py`
- Track the last emit timestamp inside `ProgressEmitter`
- Rate-limit non-finished progress emissions to once per interval
- Preserve finished progress emission so final snapshots are always delivered
- Reset emit timing state on each run reset
- Add unit coverage in `packages/vertex-forager/tests/unit/test_progress_emitter.py` for non-finished rate limiting and finished bypass behavior

## Verification

- Ran `uv run pytest packages/vertex-forager/tests/unit/test_progress_emitter.py packages/vertex-forager/tests/unit/test_pipeline_coverage.py -q`
- Ran `uv run pytest packages/ --cov-fail-under=80 -q`
- Ran `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
- Ran `uv run mypy packages/vertex-forager/src --strict`
- Ran `uv run python scripts/check_cycles.py`
- Verified results: `54 passed` for targeted tests, `550 passed` for full test suite, `ruff` pass, `mypy` pass, import cycle check pass

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 진행 상황 업데이트에 속도 제한을 도입해 짧은 간격의 반복 업데이트를 건너뜁니다.
  * 완료 상태는 속도 제한을 우회하여 즉시 업데이트됩니다.
  * 속도 제한 시 진행 스냅샷 생성 작업을 건너뛰어 불필요한 처리 비용을 줄입니다.

* **테스트**
  * 속도 제한 동작, 완료 우회 처리 및 스냅샷 건너뛰기 동작을 검증하는 단위 및 통합 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->