### PR TITLE
refactor(vertex-forager): split writer flush stages

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -25,12 +25,12 @@ import asyncio
 from collections import deque
 from collections.abc import Callable, Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
-from contextlib import contextmanager, suppress
+from contextlib import AbstractContextManager, contextmanager, suppress
 import itertools
 import logging
 import os
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 from uuid import uuid4
 
 import httpx
@@ -93,16 +93,16 @@ from vertex_forager.core.workerio import fetch_payload as fetch_payload_impl
 from vertex_forager.core.workerio import parse_payload as parse_payload_impl
 from vertex_forager.core.workerio import record_worker_error as record_worker_error_impl
 from vertex_forager.core.writerflush import (
-    WriterContext,
+    FlushExecutor,
+    FlushPlanner,
+    FlushRecovery,
     buffer_or_flush_packet,
     concat_frames_with_flex,
     flush_all_writer_buffers,
     flush_chunked_table,
     flush_on_writer_cancel,
     flush_writer_table,
-    handle_writer_flush_error,
     validate_unique_key,
-    write_merged_packet,
     writer_worker,
 )
 
@@ -329,25 +329,6 @@ class VertexForager:
             sanitize_field=sanitize_field,
             logger=logger,
         )
-        self._writer_context = WriterContext(
-            writer=self._writer,
-            config=self._config,
-            logger=logger,
-            inc=self._inc,
-            observe=self._observe,
-            log_structured=self._log_structured,
-            span=self._span,
-            validate_data_quality=self._validate_data_quality,
-            get_table_schema=get_table_schema,
-            spool_to_dlq_and_rescue=spool_to_dlq_and_rescue,
-            build_writer_error_summary=build_writer_error_summary,
-            compute_error_cls=ComputeError,
-            validation_error_cls=ValidationError,
-            dlq_spool_error_cls=DLQSpoolError,
-            duckdb_module=_duckdb,
-            progress_log_chunk_rows=PROGRESS_LOG_CHUNK_ROWS,
-            router_flexible_schema=bool(getattr(self._router, "flexible_schema", False)),
-        )
 
         # For checkpoint tracking
         self._completed_symbols: set[str] = set()
@@ -391,6 +372,12 @@ class VertexForager:
             with suppress(Exception):
                 sink.observe(name, float(value))
 
+    def on_metric(self, name: str, value: float, *, kind: Literal["counter", "observe"]) -> None:
+        if kind == "counter":
+            self._inc(name, int(value))
+            return
+        self._observe(name, value)
+
     def _compute_summary(self) -> dict[str, float]:
         def _pctl(values: list[float], p: float) -> float:
             if not values:
@@ -431,6 +418,9 @@ class VertexForager:
         with _tracer.start_as_current_span(f"vertex_forager.{name}", attributes=attributes):  # type: ignore[arg-type]
             yield
 
+    def span(self, name: str, **attributes: object) -> AbstractContextManager[object]:
+        return self._span(name, **attributes)
+
     def _log_structured(
         self,
         *,
@@ -451,6 +441,23 @@ class VertexForager:
                 "vf_attempt": int(attempt if attempt is not None else 0),
                 "vf_duration_s": None if duration_s is None else round(float(duration_s), 3),
             },
+        )
+
+    def on_log(
+        self,
+        *,
+        provider: str,
+        dataset: str,
+        symbol: str | None,
+        stage: str,
+        duration_s: float | None = None,
+    ) -> None:
+        self._log_structured(
+            provider=provider,
+            dataset=dataset,
+            symbol=symbol,
+            stage=stage,
+            duration_s=duration_s,
         )
 
     def _queued_pending_jobs(self) -> list[FetchJob]:
@@ -1588,15 +1595,15 @@ class VertexForager:
         return cast(
             ParseResult,
             await parse_payload_impl(
-            job=job,
-            payload=payload,
-            worker_id=worker_id,
-            parse_executor=self._parse_executor,
-            router_parse=self._router.parse,
-            span=self._span,
-            observe=self._observe,
-            log_structured=self._log_structured,
-            logger=logger,
+                job=job,
+                payload=payload,
+                worker_id=worker_id,
+                parse_executor=self._parse_executor,
+                router_parse=self._router.parse,
+                span=self._span,
+                observe=self._observe,
+                log_structured=self._log_structured,
+                logger=logger,
             ),
         )
 
@@ -1711,7 +1718,6 @@ class VertexForager:
         result: RunResult,
         result_lock: asyncio.Lock,
     ) -> None:
-        ctx = self._writer_context
         await writer_worker(
             pkt_q=pkt_q,
             result=result,
@@ -1720,8 +1726,8 @@ class VertexForager:
             flush_all_writer_buffers=self._flush_all_writer_buffers,
             buffer_or_flush_packet=self._buffer_or_flush_packet,
             flush_on_writer_cancel=self._flush_on_writer_cancel,
-            dlq_spool_error_cls=ctx.dlq_spool_error_cls,
-            logger=ctx.logger,
+            dlq_spool_error_cls=DLQSpoolError,
+            logger=logger,
         )
 
     async def _flush_on_writer_cancel(
@@ -1732,14 +1738,13 @@ class VertexForager:
         result: RunResult,
         result_lock: asyncio.Lock,
     ) -> None:
-        ctx = self._writer_context
         await flush_on_writer_cancel(
             buffers=buffers,
             buffer_rows=buffer_rows,
             result=result,
             result_lock=result_lock,
             flush_writer_table=self._flush_writer_table,
-            logger=ctx.logger,
+            logger=logger,
         )
 
     async def _flush_all_writer_buffers(
@@ -1750,14 +1755,13 @@ class VertexForager:
         result: RunResult,
         result_lock: asyncio.Lock,
     ) -> None:
-        ctx = self._writer_context
         await flush_all_writer_buffers(
             buffers=buffers,
             buffer_rows=buffer_rows,
             result=result,
             result_lock=result_lock,
             flush_writer_table=self._flush_writer_table,
-            logger=ctx.logger,
+            logger=logger,
         )
 
     async def _buffer_or_flush_packet(
@@ -1770,7 +1774,6 @@ class VertexForager:
         result: RunResult,
         result_lock: asyncio.Lock,
     ) -> None:
-        ctx = self._writer_context
         await buffer_or_flush_packet(
             packet=packet,
             threshold=threshold,
@@ -1779,8 +1782,8 @@ class VertexForager:
             result=result,
             result_lock=result_lock,
             flush_writer_table=self._flush_writer_table,
-            progress_log_chunk_rows=ctx.progress_log_chunk_rows,
-            logger=ctx.logger,
+            progress_log_chunk_rows=PROGRESS_LOG_CHUNK_ROWS,
+            logger=logger,
         )
 
     async def _flush_writer_table(
@@ -1792,8 +1795,6 @@ class VertexForager:
         result: RunResult,
         result_lock: asyncio.Lock,
     ) -> None:
-        ctx = self._writer_context
-
         def _concat_frames_with_flex(
             *,
             frames: list[pl.DataFrame],
@@ -1806,95 +1807,32 @@ class VertexForager:
                 table_name=table_name,
                 schema=schema,
                 rechunk=rechunk,
-                router_flexible_schema=ctx.router_flexible_schema,
-                logger=ctx.logger,
+                router_flexible_schema=bool(getattr(self._router, "flexible_schema", False)),
+                logger=logger,
             )
 
-        async def _write_merged_packet(
-            *,
-            table: str,
-            packet: FramePacket,
-            stage: str,
-            result: RunResult,
-            result_lock: asyncio.Lock,
-        ) -> None:
-            await write_merged_packet(
-                table=table,
-                packet=packet,
-                stage=stage,
-                result=result,
-                result_lock=result_lock,
-                writer=ctx.writer,
-                span=ctx.span,
-                inc=ctx.inc,
-                observe=ctx.observe,
-                log_structured=ctx.log_structured,
-            )
-
-        async def _handle_writer_flush_error(
-            *,
-            table: str,
-            packets: list[FramePacket],
-            exc: Exception,
-            prefix: str,
-            buffers: dict[str, list[FramePacket]],
-            buffer_rows: dict[str, int],
-            result: RunResult,
-            result_lock: asyncio.Lock,
-        ) -> None:
-            await handle_writer_flush_error(
-                table=table,
-                packets=packets,
-                exc=exc,
-                prefix=prefix,
-                buffers=buffers,
-                buffer_rows=buffer_rows,
-                result=result,
-                result_lock=result_lock,
-                writer=ctx.writer,
-                config=ctx.config,
-                inc=ctx.inc,
-                log_structured=ctx.log_structured,
-                spool_to_dlq_and_rescue=ctx.spool_to_dlq_and_rescue,
-                build_writer_error_summary=ctx.build_writer_error_summary,
-                dlq_spool_error_cls=ctx.dlq_spool_error_cls,
-                logger=ctx.logger,
-            )
-
-        async def _flush_chunked_table(
-            *,
-            table: str,
-            packets: list[FramePacket],
-            schema: TableSchema | None,
-            chunk_size: int,
-            buffers: dict[str, list[FramePacket]],
-            buffer_rows: dict[str, int],
-            result: RunResult,
-            result_lock: asyncio.Lock,
-        ) -> None:
-            await flush_chunked_table(
-                table=table,
-                packets=packets,
-                schema=schema,
-                chunk_size=chunk_size,
-                buffers=buffers,
-                buffer_rows=buffer_rows,
-                result=result,
-                result_lock=result_lock,
-                concat_frames_with_flex=_concat_frames_with_flex,
-                validate_unique_key=validate_unique_key,
-                validate_data_quality=ctx.validate_data_quality,
-                write_merged_packet=_write_merged_packet,
-                handle_writer_flush_error=_handle_writer_flush_error,
-                compute_error_cls=ctx.compute_error_cls,
-                validation_error_cls=ctx.validation_error_cls,
-                primary_key_missing_error_cls=PrimaryKeyMissingError,
-                primary_key_null_error_cls=PrimaryKeyNullError,
-                dlq_spool_error_cls=ctx.dlq_spool_error_cls,
-                duckdb_module=ctx.duckdb_module,
-                log_structured=ctx.log_structured,
-                logger=ctx.logger,
-            )
+        planner = FlushPlanner()
+        executor = FlushExecutor(
+            writer=self._writer,
+            observer=self,
+            concat_frames_with_flex=_concat_frames_with_flex,
+            validate_unique_key=validate_unique_key,
+            validate_data_quality=self._validate_data_quality,
+        )
+        recovery = FlushRecovery(
+            writer=self._writer,
+            config=self._config,
+            observer=self,
+            spool_to_dlq_and_rescue=spool_to_dlq_and_rescue,
+            build_writer_error_summary=build_writer_error_summary,
+            compute_error_cls=ComputeError,
+            validation_error_cls=ValidationError,
+            primary_key_missing_error_cls=PrimaryKeyMissingError,
+            primary_key_null_error_cls=PrimaryKeyNullError,
+            dlq_spool_error_cls=DLQSpoolError,
+            duckdb_module=_duckdb,
+            logger=logger,
+        )
 
         await flush_writer_table(
             table=table,
@@ -1902,8 +1840,15 @@ class VertexForager:
             buffer_rows=buffer_rows,
             result=result,
             result_lock=result_lock,
-            get_table_schema=ctx.get_table_schema,
-            flush_chunked_table=_flush_chunked_table,
+            get_table_schema=get_table_schema,
+            flush_chunked_table=lambda **kwargs: flush_chunked_table(
+                **kwargs,
+                planner=planner,
+                executor=executor,
+                recovery=recovery,
+                observer=self,
+                logger=logger,
+            ),
         )
 
     async def _fetch_with_retry(self, job: FetchJob) -> bytes:

--- a/packages/vertex-forager/src/vertex_forager/core/writerflush.py
+++ b/packages/vertex-forager/src/vertex_forager/core/writerflush.py
@@ -514,7 +514,7 @@ class FlushRecovery:
                 self.logger.error("WRITER: Error writing chunk for %s: %s", table, exc)
             return
         if isinstance(exc, self.dlq_spool_error_cls):
-            raise
+            raise exc
         prefix = "DuckDBError" if _is_duckdb_error(self.duckdb_module, exc) else "UnexpectedWriterError"
         await handle_writer_flush_error(
             table=table,

--- a/packages/vertex-forager/src/vertex_forager/core/writerflush.py
+++ b/packages/vertex-forager/src/vertex_forager/core/writerflush.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import time
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
 
 import polars as pl
 
@@ -23,9 +23,7 @@ if TYPE_CHECKING:
     from vertex_forager.schema.config import TableSchema
     from vertex_forager.writers.base import WriteResult
 
-LogStructuredFunc = Callable[..., None]
-IncFunc = Callable[[str, int], None]
-ObserveFunc = Callable[[str, float], None]
+MetricKind = Literal["counter", "observe"]
 AsyncFunc = Callable[..., Awaitable[None]]
 
 
@@ -47,25 +45,29 @@ class ConfigLike(Protocol):
     pass
 
 
-@dataclass(frozen=True)
-class WriterContext:
-    writer: WriterLike
-    config: ConfigLike
-    logger: LoggerLike
-    inc: IncFunc
-    observe: ObserveFunc
-    log_structured: LogStructuredFunc
-    span: Callable[..., AbstractContextManager[object]]
-    validate_data_quality: Callable[..., Awaitable[None]]
-    get_table_schema: Callable[[str], TableSchema | None]
-    spool_to_dlq_and_rescue: Callable[..., Awaitable[object]]
-    build_writer_error_summary: Callable[..., RunError]
-    compute_error_cls: type[Exception]
-    validation_error_cls: type[Exception]
-    dlq_spool_error_cls: type[Exception]
-    duckdb_module: object | None
-    progress_log_chunk_rows: int
-    router_flexible_schema: bool
+@runtime_checkable
+class FlushObserver(Protocol):
+    def on_metric(self, name: str, value: float, *, kind: MetricKind) -> None: ...
+
+    def on_log(
+        self,
+        *,
+        provider: str,
+        dataset: str,
+        symbol: str | None,
+        stage: str,
+        duration_s: float | None = None,
+    ) -> None: ...
+
+    def span(self, name: str, **attributes: object) -> AbstractContextManager[object]: ...
+
+
+def _counter(observer: FlushObserver, name: str, amount: int) -> None:
+    observer.on_metric(name, float(amount), kind="counter")
+
+
+def _observe(observer: FlushObserver, name: str, value: float) -> None:
+    observer.on_metric(name, value, kind="observe")
 
 
 async def writer_worker(
@@ -234,14 +236,13 @@ async def handle_writer_flush_error(
     result_lock: asyncio.Lock,
     writer: WriterLike,
     config: ConfigLike,
-    inc: IncFunc,
-    log_structured: LogStructuredFunc,
+    observer: FlushObserver,
     spool_to_dlq_and_rescue: Callable[..., Awaitable[object]],
     build_writer_error_summary: Callable[..., RunError],
     dlq_spool_error_cls: type[Exception],
     logger: LoggerLike,
 ) -> None:
-    inc("errors_total", 1)
+    _counter(observer, "errors_total", 1)
     provider, symbol = writer_table_context(packets)
     try:
         status = await spool_to_dlq_and_rescue(
@@ -251,8 +252,8 @@ async def handle_writer_flush_error(
             config=config,
             result=result,
             result_lock=result_lock,
-            inc=inc,
-            log_structured=log_structured,
+            inc=lambda name, amount=1: _counter(observer, name, amount),
+            log_structured=lambda **kwargs: observer.on_log(**kwargs),
         )
     except Exception as spool_exc:
         if isinstance(spool_exc, dlq_spool_error_cls):
@@ -348,22 +349,19 @@ async def write_merged_packet(
     result: RunResult,
     result_lock: asyncio.Lock,
     writer: WriterLike,
-    span: Callable[..., AbstractContextManager[object]],
-    inc: IncFunc,
-    observe: ObserveFunc,
-    log_structured: LogStructuredFunc,
+    observer: FlushObserver,
 ) -> None:
     t_w0 = time.monotonic()
-    with span("write_flush", table=table, rows=len(packet.frame)):
+    with observer.span("write_flush", table=table, rows=len(packet.frame)):
         write_result = await writer.write(packet)
     t_w1 = time.monotonic()
-    inc("writer_flushes", 1)
-    observe("writer_flush_duration_s", float(t_w1 - t_w0))
-    observe("writer_rows", float(write_result.rows))
-    observe(f"writer_flush_duration_s.{table}", float(t_w1 - t_w0))
-    observe(f"writer_rows.{table}", float(write_result.rows))
-    inc("rows_written_total", int(write_result.rows))
-    log_structured(
+    _counter(observer, "writer_flushes", 1)
+    _observe(observer, "writer_flush_duration_s", float(t_w1 - t_w0))
+    _observe(observer, "writer_rows", float(write_result.rows))
+    _observe(observer, f"writer_flush_duration_s.{table}", float(t_w1 - t_w0))
+    _observe(observer, f"writer_rows.{table}", float(write_result.rows))
+    _counter(observer, "rows_written_total", int(write_result.rows))
+    observer.on_log(
         provider=packet.provider,
         dataset=packet.table,
         symbol=None,
@@ -372,6 +370,173 @@ async def write_merged_packet(
     )
     async with result_lock:
         result.tables[write_result.table] = result.tables.get(write_result.table, 0) + write_result.rows
+
+
+@dataclass(frozen=True)
+class FlushChunk:
+    index: int
+    start_index: int
+    packets: list[FramePacket]
+    frames: list[pl.DataFrame]
+    rows: int
+
+
+@dataclass(frozen=True)
+class FlushPlanner:
+    def plan(self, *, packets: list[FramePacket], chunk_size: int) -> list[FlushChunk]:
+        chunks: list[FlushChunk] = []
+        i = 0
+        idx = 0
+        while i < len(packets):
+            rows_in_chunk = 0
+            current_packets: list[FramePacket] = []
+            current_frames: list[pl.DataFrame] = []
+            start_i = i
+            while i < len(packets) and rows_in_chunk < chunk_size:
+                pkt = packets[i]
+                current_packets.append(pkt)
+                current_frames.append(pkt.frame)
+                rows_in_chunk += len(pkt.frame)
+                i += 1
+            chunks.append(
+                FlushChunk(
+                    index=idx,
+                    start_index=start_i,
+                    packets=current_packets,
+                    frames=current_frames,
+                    rows=rows_in_chunk,
+                )
+            )
+            idx += 1
+        return chunks
+
+
+@dataclass(frozen=True)
+class FlushExecutor:
+    writer: WriterLike
+    observer: FlushObserver
+    concat_frames_with_flex: Callable[..., pl.DataFrame]
+    validate_unique_key: Callable[..., None]
+    validate_data_quality: AsyncFunc
+
+    async def execute(
+        self,
+        *,
+        table: str,
+        chunk: FlushChunk,
+        schema: TableSchema | None,
+        result: RunResult,
+        result_lock: asyncio.Lock,
+    ) -> None:
+        first = chunk.packets[0]
+        chunk_df = self.concat_frames_with_flex(
+            frames=chunk.frames,
+            table_name=first.table,
+            schema=schema,
+            rechunk=False,
+        )
+        await self.validate_data_quality(table=table, df=chunk_df, result=result, result_lock=result_lock)
+        self.validate_unique_key(schema=schema, table=table, frame=chunk_df)
+        chunk_packet = FramePacket(
+            provider=first.provider,
+            table=first.table,
+            frame=chunk_df,
+            observed_at=first.observed_at,
+            context=first.context,
+        )
+        await write_merged_packet(
+            table=table,
+            packet=chunk_packet,
+            stage=f"write_flush_chunk_{chunk.index + 1}",
+            result=result,
+            result_lock=result_lock,
+            writer=self.writer,
+            observer=self.observer,
+        )
+
+
+@dataclass(frozen=True)
+class FlushRecovery:
+    writer: WriterLike
+    config: ConfigLike
+    observer: FlushObserver
+    spool_to_dlq_and_rescue: Callable[..., Awaitable[object]]
+    build_writer_error_summary: Callable[..., RunError]
+    compute_error_cls: type[Exception]
+    validation_error_cls: type[Exception]
+    primary_key_missing_error_cls: type[Exception]
+    primary_key_null_error_cls: type[Exception]
+    dlq_spool_error_cls: type[Exception]
+    duckdb_module: object | None
+    logger: LoggerLike
+
+    async def recover(
+        self,
+        *,
+        table: str,
+        chunk: FlushChunk,
+        packets: list[FramePacket],
+        exc: Exception,
+        buffers: dict[str, list[FramePacket]],
+        buffer_rows: dict[str, int],
+        result: RunResult,
+        result_lock: asyncio.Lock,
+    ) -> None:
+        remaining_packets = packets[chunk.start_index : len(packets)]
+        if isinstance(exc, (self.compute_error_cls, self.validation_error_cls)):
+            await handle_writer_flush_error(
+                table=table,
+                packets=remaining_packets,
+                exc=exc,
+                prefix="WriterError",
+                buffers=buffers,
+                buffer_rows=buffer_rows,
+                result=result,
+                result_lock=result_lock,
+                writer=self.writer,
+                config=self.config,
+                observer=self.observer,
+                spool_to_dlq_and_rescue=self.spool_to_dlq_and_rescue,
+                build_writer_error_summary=self.build_writer_error_summary,
+                dlq_spool_error_cls=self.dlq_spool_error_cls,
+                logger=self.logger,
+            )
+            if isinstance(exc, self.primary_key_missing_error_cls):
+                self.logger.error("WRITER: PKMissing table=%s column=%s", table, getattr(exc, "column", ""))
+            elif isinstance(exc, self.primary_key_null_error_cls):
+                self.logger.error(
+                    "WRITER: PKNull table=%s column=%s nulls=%s",
+                    table,
+                    getattr(exc, "column", ""),
+                    getattr(exc, "null_count", ""),
+                )
+            else:
+                self.logger.error("WRITER: Error writing chunk for %s: %s", table, exc)
+            return
+        if isinstance(exc, self.dlq_spool_error_cls):
+            raise
+        prefix = "DuckDBError" if _is_duckdb_error(self.duckdb_module, exc) else "UnexpectedWriterError"
+        await handle_writer_flush_error(
+            table=table,
+            packets=remaining_packets,
+            exc=exc,
+            prefix=prefix,
+            buffers=buffers,
+            buffer_rows=buffer_rows,
+            result=result,
+            result_lock=result_lock,
+            writer=self.writer,
+            config=self.config,
+            observer=self.observer,
+            spool_to_dlq_and_rescue=self.spool_to_dlq_and_rescue,
+            build_writer_error_summary=self.build_writer_error_summary,
+            dlq_spool_error_cls=self.dlq_spool_error_cls,
+            logger=self.logger,
+        )
+        if prefix == "DuckDBError":
+            self.logger.exception("WRITER: DuckDB error for %s: %s", table, exc)
+        else:
+            self.logger.exception("WRITER: Unexpected error writing chunk for %s: %s", table, exc)
 
 
 async def flush_chunked_table(
@@ -384,18 +549,10 @@ async def flush_chunked_table(
     buffer_rows: dict[str, int],
     result: RunResult,
     result_lock: asyncio.Lock,
-    concat_frames_with_flex: Callable[..., pl.DataFrame],
-    validate_unique_key: Callable[..., None],
-    validate_data_quality: AsyncFunc,
-    write_merged_packet: AsyncFunc,
-    handle_writer_flush_error: AsyncFunc,
-    compute_error_cls: type[Exception],
-    validation_error_cls: type[Exception],
-    primary_key_missing_error_cls: type[Exception],
-    primary_key_null_error_cls: type[Exception],
-    dlq_spool_error_cls: type[Exception],
-    duckdb_module: object | None,
-    log_structured: LogStructuredFunc,
+    planner: FlushPlanner,
+    executor: FlushExecutor,
+    recovery: FlushRecovery,
+    observer: FlushObserver,
     logger: LoggerLike,
 ) -> None:
     first = packets[0]
@@ -409,91 +566,32 @@ async def flush_chunked_table(
             chunk_size,
             est_chunks,
         )
-        log_structured(
+        observer.on_log(
             provider=first.provider,
             dataset=first.table,
             symbol=None,
             stage=f"write_chunking_rows_{total_rows_est}_size_{chunk_size}_chunks_{est_chunks}",
         )
-    i = 0
-    idx = 0
-    while i < len(packets):
-        rows_in_chunk = 0
-        current_frames: list[pl.DataFrame] = []
-        start_i = i
-        while i < len(packets) and rows_in_chunk < chunk_size:
-            pkt = packets[i]
-            current_frames.append(pkt.frame)
-            rows_in_chunk += len(pkt.frame)
-            i += 1
+    for chunk in planner.plan(packets=packets, chunk_size=chunk_size):
         try:
-            chunk_df = concat_frames_with_flex(
-                frames=current_frames,
-                table_name=first.table,
-                schema=schema,
-                rechunk=False,
-            )
-            await validate_data_quality(table=table, df=chunk_df, result=result, result_lock=result_lock)
-            validate_unique_key(schema=schema, table=table, frame=chunk_df)
-            chunk_packet = FramePacket(
-                provider=first.provider,
-                table=first.table,
-                frame=chunk_df,
-                observed_at=first.observed_at,
-                context=first.context,
-            )
-            await write_merged_packet(
+            await executor.execute(
                 table=table,
-                packet=chunk_packet,
-                stage=f"write_flush_chunk_{idx + 1}",
+                chunk=chunk,
+                schema=schema,
                 result=result,
                 result_lock=result_lock,
             )
-            idx += 1
         except Exception as exc:
-            if isinstance(exc, (compute_error_cls, validation_error_cls)):
-                remaining_packets = packets[start_i : len(packets)]
-                await handle_writer_flush_error(
-                    table=table,
-                    packets=remaining_packets,
-                    exc=exc,
-                    prefix="WriterError",
-                    buffers=buffers,
-                    buffer_rows=buffer_rows,
-                    result=result,
-                    result_lock=result_lock,
-                )
-                if isinstance(exc, primary_key_missing_error_cls):
-                    logger.error("WRITER: PKMissing table=%s column=%s", table, getattr(exc, "column", ""))
-                elif isinstance(exc, primary_key_null_error_cls):
-                    logger.error(
-                        "WRITER: PKNull table=%s column=%s nulls=%s",
-                        table,
-                        getattr(exc, "column", ""),
-                        getattr(exc, "null_count", ""),
-                    )
-                else:
-                    logger.error("WRITER: Error writing chunk for %s: %s", table, exc)
-                return
-            if isinstance(exc, dlq_spool_error_cls):
-                raise
-            remaining_packets = packets[start_i : len(packets)]
-            is_duckdb_error = _is_duckdb_error(duckdb_module, exc)
-            prefix = "DuckDBError" if is_duckdb_error else "UnexpectedWriterError"
-            await handle_writer_flush_error(
+            await recovery.recover(
                 table=table,
-                packets=remaining_packets,
+                chunk=chunk,
+                packets=packets,
                 exc=exc,
-                prefix=prefix,
                 buffers=buffers,
                 buffer_rows=buffer_rows,
                 result=result,
                 result_lock=result_lock,
             )
-            if prefix == "DuckDBError":
-                logger.exception("WRITER: DuckDB error for %s: %s", table, exc)
-            else:
-                logger.exception("WRITER: Unexpected error writing chunk for %s: %s", table, exc)
             return
 
 

--- a/packages/vertex-forager/tests/unit/test_core_writerflush.py
+++ b/packages/vertex-forager/tests/unit/test_core_writerflush.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
+from contextlib import contextmanager
 from datetime import datetime
 
 import polars as pl
@@ -10,13 +11,17 @@ import pytest
 from vertex_forager.constants import WRITER_CHUNK_ROWS
 from vertex_forager.core.config import FramePacket, RunResult
 from vertex_forager.core.writerflush import (
+    FlushChunk,
+    FlushExecutor,
+    FlushPlanner,
+    FlushRecovery,
     buffer_or_flush_packet,
     flush_writer_table,
     validate_unique_key,
     writer_table_context,
     writer_worker,
 )
-from vertex_forager.exceptions import PrimaryKeyMissingError
+from vertex_forager.exceptions import PrimaryKeyMissingError, RunError
 from vertex_forager.schema.config import TableSchema
 
 
@@ -27,6 +32,36 @@ def _packet(table: str, rows: int = 1) -> FramePacket:
         frame=pl.DataFrame({"x": list(range(rows))}),
         observed_at=datetime.now(),
     )
+
+
+class _Observer:
+    def __init__(self) -> None:
+        self.metrics: list[tuple[str, float, str]] = []
+        self.logs: list[dict[str, object]] = []
+
+    def on_metric(self, name: str, value: float, *, kind: str) -> None:
+        self.metrics.append((name, value, kind))
+
+    def on_log(self, **kwargs: object) -> None:
+        self.logs.append(dict(kwargs))
+
+    @contextmanager
+    def span(self, name: str, **attributes: object) -> object:
+        del name, attributes
+        yield
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.packets: list[FramePacket] = []
+
+    async def write(self, packet: FramePacket) -> object:
+        self.packets.append(packet)
+        return type("WriteResult", (), {"rows": len(packet.frame), "table": packet.table})()
+
+
+class _ValidationError(Exception):
+    pass
 
 
 @pytest.mark.asyncio
@@ -103,6 +138,109 @@ def test_validate_unique_key_raises_missing_column() -> None:
 
     with pytest.raises(PrimaryKeyMissingError):
         validate_unique_key(schema=schema, table="t", frame=pl.DataFrame({"x": [1]}))
+
+
+def test_flush_planner_splits_packets_by_chunk_rows() -> None:
+    planner = FlushPlanner()
+    chunks = planner.plan(packets=[_packet("t", 2), _packet("t", 2), _packet("t", 3)], chunk_size=4)
+
+    assert [(chunk.index, chunk.start_index, chunk.rows, len(chunk.packets)) for chunk in chunks] == [
+        (0, 0, 4, 2),
+        (1, 2, 3, 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_flush_executor_validates_and_writes_chunk() -> None:
+    observer = _Observer()
+    writer = _Writer()
+    calls = {"quality": 0, "unique": 0}
+
+    async def _validate_quality(**kwargs: object) -> None:
+        calls["quality"] += 1
+        assert kwargs["table"] == "t"
+
+    def _validate_unique(**kwargs: object) -> None:
+        calls["unique"] += 1
+        assert kwargs["table"] == "t"
+
+    executor = FlushExecutor(
+        writer=writer,
+        observer=observer,
+        concat_frames_with_flex=lambda **kwargs: pl.concat(kwargs["frames"], how="vertical"),
+        validate_unique_key=_validate_unique,
+        validate_data_quality=_validate_quality,
+    )
+    packets = [_packet("t", 2), _packet("t", 1)]
+    chunk = FlushChunk(index=0, start_index=0, packets=packets, frames=[packet.frame for packet in packets], rows=3)
+    result = RunResult(provider="sharadar")
+
+    await executor.execute(
+        table="t",
+        chunk=chunk,
+        schema=TableSchema(table="t", schema={"x": pl.Int64}),
+        result=result,
+        result_lock=asyncio.Lock(),
+    )
+
+    assert calls == {"quality": 1, "unique": 1}
+    assert len(writer.packets) == 1
+    assert len(writer.packets[0].frame) == 3
+    assert result.tables == {"t": 3}
+    assert any(metric[0] == "writer_flushes" for metric in observer.metrics)
+    assert observer.logs[0]["stage"] == "write_flush_chunk_1"
+
+
+@pytest.mark.asyncio
+async def test_flush_recovery_handles_validation_errors_with_writererror_prefix() -> None:
+    observer = _Observer()
+    build_calls: list[dict[str, object]] = []
+    spool_calls: list[dict[str, object]] = []
+
+    async def _spool(**kwargs: object) -> object:
+        spool_calls.append(dict(kwargs))
+        return {"status": "spooled", "rescued": 0, "remaining": len(kwargs["packets"]), "path": "x", "error": None}
+
+    def _build_summary(**kwargs: object) -> RunError:
+        build_calls.append(dict(kwargs))
+        return RunError.from_exception(exc=kwargs["exc"], provider="sharadar", dataset="t", symbol="")
+
+    recovery = FlushRecovery(
+        writer=_Writer(),
+        config=object(),
+        observer=observer,
+        spool_to_dlq_and_rescue=_spool,
+        build_writer_error_summary=_build_summary,
+        compute_error_cls=Exception,
+        validation_error_cls=_ValidationError,
+        primary_key_missing_error_cls=PrimaryKeyMissingError,
+        primary_key_null_error_cls=Exception,
+        dlq_spool_error_cls=Exception,
+        duckdb_module=None,
+        logger=type("L", (), {"error": lambda *args, **kwargs: None, "exception": lambda *args, **kwargs: None})(),
+    )
+    packets = [_packet("t", 1), _packet("t", 1), _packet("t", 1)]
+    chunk = FlushChunk(index=1, start_index=1, packets=packets[1:], frames=[p.frame for p in packets[1:]], rows=2)
+    result = RunResult(provider="sharadar")
+    buffers = {"t": packets.copy()}
+    buffer_rows = {"t": 3}
+
+    await recovery.recover(
+        table="t",
+        chunk=chunk,
+        packets=packets,
+        exc=_ValidationError("bad"),
+        buffers=buffers,
+        buffer_rows=buffer_rows,
+        result=result,
+        result_lock=asyncio.Lock(),
+    )
+
+    assert build_calls[0]["prefix"] == "WriterError"
+    assert len(spool_calls[0]["packets"]) == 2
+    assert len(result.errors) == 1
+    assert buffers["t"] == []
+    assert buffer_rows["t"] == 0
 
 
 @pytest.mark.asyncio

--- a/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
+++ b/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime
 import os
 import time
@@ -50,9 +50,9 @@ class _NoopObserver:
     def on_log(**kwargs: object) -> None:
         pass
 
-    @staticmethod
     @contextmanager
-    def span(name: str, **attributes: object) -> object:
+    def span(self, name: str, **attributes: object) -> AbstractContextManager[object]:
+        del self
         del name, attributes
         yield
 

--- a/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
+++ b/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
@@ -11,7 +11,13 @@ import pytest
 
 from vertex_forager.core.config import FetchJob, FramePacket, RequestSpec, RetryConfig, RunResult
 from vertex_forager.core.retry import RetryExecutor
-from vertex_forager.core.writerflush import FlushExecutor, FlushPlanner, FlushRecovery, flush_chunked_table
+from vertex_forager.core.writerflush import (
+    FlushExecutor,
+    FlushPlanner,
+    FlushRecovery,
+    MetricKind,
+    flush_chunked_table,
+)
 from vertex_forager.exceptions import RunError
 
 pytestmark = pytest.mark.manual
@@ -37,7 +43,7 @@ class _NoopLogger:
 
 class _NoopObserver:
     @staticmethod
-    def on_metric(name: str, value: float, *, kind: str) -> None:
+    def on_metric(name: str, value: float, *, kind: MetricKind) -> None:
         pass
 
     @staticmethod

--- a/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
+++ b/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from datetime import datetime
 import os
 import time
@@ -10,7 +11,8 @@ import pytest
 
 from vertex_forager.core.config import FetchJob, FramePacket, RequestSpec, RetryConfig, RunResult
 from vertex_forager.core.retry import RetryExecutor
-from vertex_forager.core.writerflush import flush_chunked_table
+from vertex_forager.core.writerflush import FlushExecutor, FlushPlanner, FlushRecovery, flush_chunked_table
+from vertex_forager.exceptions import RunError
 
 pytestmark = pytest.mark.manual
 
@@ -31,6 +33,27 @@ class _NoopLogger:
     @staticmethod
     def exception(msg: str, *args: object) -> None:
         pass
+
+
+class _NoopObserver:
+    @staticmethod
+    def on_metric(name: str, value: float, *, kind: str) -> None:
+        pass
+
+    @staticmethod
+    def on_log(**kwargs: object) -> None:
+        pass
+
+    @staticmethod
+    @contextmanager
+    def span(name: str, **attributes: object) -> object:
+        del name, attributes
+        yield
+
+
+class _NoopWriter:
+    async def write(self, packet: FramePacket) -> object:
+        return type("WriteResult", (), {"rows": len(packet.frame), "table": packet.table})()
 
 
 class _Throttle:
@@ -92,18 +115,31 @@ async def test_retry_and_writer_chunk_perf_budget() -> None:
         buffer_rows={"t": sum(len(p.frame) for p in packets)},
         result=RunResult(provider="test"),
         result_lock=asyncio.Lock(),
-        concat_frames_with_flex=lambda **kwargs: pl.concat(kwargs["frames"], how="vertical"),
-        validate_unique_key=lambda **kwargs: None,
-        validate_data_quality=lambda **kwargs: _noop_async(),
-        write_merged_packet=lambda **kwargs: _noop_async(),
-        handle_writer_flush_error=lambda **kwargs: _noop_async(),
-        compute_error_cls=Exception,
-        validation_error_cls=Exception,
-        primary_key_missing_error_cls=Exception,
-        primary_key_null_error_cls=Exception,
-        dlq_spool_error_cls=Exception,
-        duckdb_module=None,
-        log_structured=lambda **kwargs: None,
+        planner=FlushPlanner(),
+        executor=FlushExecutor(
+            writer=_NoopWriter(),
+            observer=_NoopObserver(),
+            concat_frames_with_flex=lambda **kwargs: pl.concat(kwargs["frames"], how="vertical"),
+            validate_unique_key=lambda **kwargs: None,
+            validate_data_quality=lambda **kwargs: _noop_async(),
+        ),
+        recovery=FlushRecovery(
+            writer=_NoopWriter(),
+            config=object(),
+            observer=_NoopObserver(),
+            spool_to_dlq_and_rescue=lambda **kwargs: _noop_status(),
+            build_writer_error_summary=lambda **kwargs: RunError.from_exception(
+                exc=kwargs["exc"], provider="test", dataset="t", symbol=""
+            ),
+            compute_error_cls=Exception,
+            validation_error_cls=Exception,
+            primary_key_missing_error_cls=Exception,
+            primary_key_null_error_cls=Exception,
+            dlq_spool_error_cls=Exception,
+            duckdb_module=None,
+            logger=_NoopLogger(),
+        ),
+        observer=_NoopObserver(),
         logger=_NoopLogger(),
     )
     writer_elapsed = time.monotonic() - t1
@@ -125,3 +161,7 @@ async def _return_bytes() -> bytes:
 
 async def _noop_async() -> None:
     return None
+
+
+async def _noop_status() -> dict[str, object]:
+    return {"status": "spooled", "rescued": 0, "remaining": 0, "path": None, "error": None}


### PR DESCRIPTION
## Summary

- Replace the callback-heavy writer flush context with a narrow `FlushObserver` interface implemented directly by `VertexForager`.
- Split the writer flush path into planner, executor, and recovery stages so chunk planning, write execution, and DLQ/error handling can be tested independently.

## Linked Issue

- Closes #477

## Changes

- Remove `WriterContext` from `packages/vertex-forager/src/vertex_forager/core/writerflush.py`
- Add `FlushObserver` protocol for flush metrics, structured logs, and spans
- Add `FlushChunk`, `FlushPlanner`, `FlushExecutor`, and `FlushRecovery`
- Refactor `flush_chunked_table()` into a thin orchestrator over the new flush stages
- Update `packages/vertex-forager/src/vertex_forager/core/pipeline.py` so `VertexForager` satisfies `FlushObserver` directly via `on_metric()`, `on_log()`, and `span()`
- Rewire the writer flush path in `pipeline.py` to compose `FlushPlanner`, `FlushExecutor`, and `FlushRecovery` instead of building a large callback container
- Add stage-focused unit coverage in `packages/vertex-forager/tests/unit/test_core_writerflush.py`
- Update `packages/vertex-forager/tests/verification/verify_core_perf_budget.py` to the new flush API

## Verification

- Ran `uv run pytest packages/vertex-forager/tests/unit/test_core_writerflush.py packages/vertex-forager/tests/unit/test_pipeline_coverage.py -q`
- Ran `uv run pytest packages/ --cov-fail-under=80 -q`
- Ran `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
- Ran `uv run mypy packages/vertex-forager/src --strict`
- Ran `uv run python scripts/check_cycles.py`
- Verified results: `59 passed` for targeted tests, `554 passed` for full test suite, `ruff` pass, `mypy` pass, import cycle check pass

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 메트릭/로그/범위 관찰자 공개 API 추가: on_metric(), on_log(), span()

* **리팩토링**
  * 쓰기/플러시 오케스트레이션 구조 재설계 — 플래너/실행자/복구/관찰자 컴포넌트 도입으로 내부 흐름 단순화 및 관찰자 기반 메트릭·로그 통합

* **테스트**
  * 플래너·실행자·복구 동작을 검증하는 단위 및 성능 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->