### PR TITLE
perf(vertex-forager): streamline scheduler hot paths

### DIFF
--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -784,7 +784,7 @@ class VertexForager:
                 self._summary["req_q_len_after_producer"] = float(req_q.qsize())
                 self._summary["pkt_q_len_after_producer"] = float(pkt_q.qsize())
         await req_q.join()
-        await wait_for_pagination_drain_impl(fairness_state=self._fair_state)
+        await wait_for_pagination_drain_impl(fair_lock=self._fair_lock, fairness_state=self._fair_state)
         logger.info("PIPELINE: Request queue joined, sending sentinel signals...")
         with suppress(Exception):
             self._summary["req_q_len_after_req_join"] = float(req_q.qsize())
@@ -1487,7 +1487,7 @@ class VertexForager:
             if selected.job is not None:
                 return selected
             pagination_wait = asyncio.create_task(
-                wait_for_pagination_availability_impl(fairness_state=self._fair_state)
+                wait_for_pagination_availability_impl(fair_lock=self._fair_lock, fairness_state=self._fair_state)
             )
             req_get = asyncio.create_task(self._get_request_queue(req_q=req_q))
             pending_tasks = (pagination_wait, req_get)

--- a/packages/vertex-forager/src/vertex_forager/core/pipeline.py
+++ b/packages/vertex-forager/src/vertex_forager/core/pipeline.py
@@ -393,6 +393,12 @@ class VertexForager:
             s[f"{key}_p99"] = _pctl(vals, 99.0)
         # Per-table writer latencies and rows per flush
         for key, vals_deque in self._hists.items():
+            if key.startswith("parse_duration_s."):
+                target = key.split(".", 1)[1]
+                vals = list(vals_deque)
+                s[f"parse_duration_s.{target}_p50"] = _pctl(vals, 50.0)
+                s[f"parse_duration_s.{target}_p95"] = _pctl(vals, 95.0)
+                s[f"parse_duration_s.{target}_p99"] = _pctl(vals, 99.0)
             if key.startswith("writer_flush_duration_s."):
                 table = key.split(".", 1)[1]
                 vals = list(vals_deque)

--- a/packages/vertex-forager/src/vertex_forager/core/scheduler.py
+++ b/packages/vertex-forager/src/vertex_forager/core/scheduler.py
@@ -13,12 +13,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class FairnessState:
-    """Mutable DRR pagination scheduling state.
-
-    available is level-triggered state, not an edge-triggered wakeup signal.
-    It stays set while any active symbol still has pending pagination work and
-    is cleared only when the DRR lane becomes empty.
-    """
+    """Pure mutable DRR pagination scheduling state."""
 
     queues: dict[str, deque[FetchJob]] = field(default_factory=dict)
     deficit: dict[str, float] = field(default_factory=dict)
@@ -28,22 +23,103 @@ class FairnessState:
     max_pending_per_symbol: int | None = None
     backpressure_threshold: int | None = None
     unfinished_jobs: int = 0
-    drained: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
-    available: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
-    below_threshold: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
-    symbol_capacity: dict[str, asyncio.Event] = field(default_factory=dict, repr=False)
+    total_backlog: int = 0
 
     def __post_init__(self) -> None:
-        if self.unfinished_jobs == 0:
-            self.drained.set()
         if not math.isfinite(self.quantum) or self.quantum <= 0:
             raise ValueError(f"quantum must be a finite positive number, got {self.quantum}")
         if self.max_pending_per_symbol is not None and self.max_pending_per_symbol <= 0:
             raise ValueError("max_pending_per_symbol must be positive when specified")
         if self.backpressure_threshold is not None and self.backpressure_threshold <= 0:
             raise ValueError("backpressure_threshold must be positive when specified")
-        if self.backpressure_threshold is None or _queued_backlog(fairness_state=self) < self.backpressure_threshold:
+
+
+@dataclass
+class FairnessEvents:
+    drained: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    available: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    below_threshold: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    symbol_capacity: dict[str, asyncio.Event] = field(default_factory=dict, repr=False)
+    enqueue_ready: dict[str, asyncio.Event] = field(default_factory=dict, repr=False)
+
+    def _ensure_symbol_capacity_event(self, symbol: str) -> asyncio.Event:
+        event = self.symbol_capacity.get(symbol)
+        if event is None:
+            event = asyncio.Event()
+            self.symbol_capacity[symbol] = event
+        return event
+
+    def _ensure_enqueue_ready_event(self, symbol: str) -> asyncio.Event:
+        event = self.enqueue_ready.get(symbol)
+        if event is None:
+            event = asyncio.Event()
+            self.enqueue_ready[symbol] = event
+        return event
+
+    def _cleanup_symbol_events(self, symbol: str) -> None:
+        capacity_event = self.symbol_capacity.pop(symbol, None)
+        if capacity_event is not None:
+            capacity_event.set()
+        enqueue_event = self.enqueue_ready.pop(symbol, None)
+        if enqueue_event is not None:
+            enqueue_event.set()
+
+    def sync_symbol(self, *, fairness_state: FairnessState, symbol: str, depth: int) -> None:
+        capacity_ok = (
+            fairness_state.max_pending_per_symbol is None or depth < fairness_state.max_pending_per_symbol
+        )
+        threshold_ok = (
+            fairness_state.backpressure_threshold is None
+            or fairness_state.total_backlog < fairness_state.backpressure_threshold
+        )
+        if fairness_state.max_pending_per_symbol is None and depth == 0 and symbol not in fairness_state.queues:
+            self._cleanup_symbol_events(symbol)
+            return
+        capacity_event = self._ensure_symbol_capacity_event(symbol)
+        if capacity_ok:
+            capacity_event.set()
+        else:
+            capacity_event.clear()
+        enqueue_ready_event = self._ensure_enqueue_ready_event(symbol)
+        if capacity_ok and threshold_ok:
+            enqueue_ready_event.set()
+        else:
+            enqueue_ready_event.clear()
+
+    def sync_from_state(self, *, fairness_state: FairnessState) -> None:
+        if fairness_state.unfinished_jobs == 0:
+            self.drained.set()
+        else:
+            self.drained.clear()
+        if fairness_state.active:
+            self.available.set()
+        else:
+            self.available.clear()
+        threshold_ok = (
+            fairness_state.backpressure_threshold is None
+            or fairness_state.total_backlog < fairness_state.backpressure_threshold
+        )
+        if threshold_ok:
             self.below_threshold.set()
+        else:
+            self.below_threshold.clear()
+        tracked_symbols = (
+            set(fairness_state.queues)
+            | set(self.symbol_capacity)
+            | set(self.enqueue_ready)
+            | set(fairness_state.active_symbols)
+        )
+        for symbol in tracked_symbols:
+            depth = len(fairness_state.queues.get(symbol, ()))
+            self.sync_symbol(fairness_state=fairness_state, symbol=symbol, depth=depth)
+
+    def wait_event_for(self, *, fairness_state: FairnessState, symbol: str) -> asyncio.Event:
+        self.sync_symbol(
+            fairness_state=fairness_state,
+            symbol=symbol,
+            depth=len(fairness_state.queues.get(symbol, ())),
+        )
+        return self._ensure_enqueue_ready_event(symbol)
 
 
 @dataclass(frozen=True)
@@ -58,64 +134,141 @@ def _symbol_key(job: FetchJob) -> str:
     return job.symbol or ""
 
 
-def _ensure_symbol_capacity_event(*, fairness_state: FairnessState, symbol: str) -> asyncio.Event:
-    event = fairness_state.symbol_capacity.get(symbol)
-    if event is None:
-        event = asyncio.Event()
-        fairness_state.symbol_capacity[symbol] = event
-    return event
+class FairnessWaiter:
+    def __init__(
+        self,
+        *,
+        fair_lock: asyncio.Lock,
+        fairness_state: FairnessState,
+        fairness_events: FairnessEvents,
+    ) -> None:
+        self._lock = fair_lock
+        self._state = fairness_state
+        self._events = fairness_events
+        self._events.sync_from_state(fairness_state=self._state)
+
+    def _try_enqueue_pagination_job(self, *, symbol: str, job: FetchJob) -> asyncio.Event | None:
+        q = self._state.queues.get(symbol)
+        current_depth = len(q) if q is not None else 0
+        backlog_blocked = (
+            self._state.backpressure_threshold is not None
+            and self._state.total_backlog >= self._state.backpressure_threshold
+        )
+        symbol_blocked = (
+            self._state.max_pending_per_symbol is not None
+            and current_depth >= self._state.max_pending_per_symbol
+        )
+        if backlog_blocked or symbol_blocked:
+            self._events.sync_from_state(fairness_state=self._state)
+            return self._events.wait_event_for(fairness_state=self._state, symbol=symbol)
+        if q is None:
+            q = deque()
+            self._state.queues[symbol] = q
+        q.append(job)
+        if symbol not in self._state.active_symbols:
+            self._state.active.append(symbol)
+            self._state.active_symbols.add(symbol)
+        self._state.unfinished_jobs += 1
+        self._state.total_backlog += 1
+        self._events.sync_from_state(fairness_state=self._state)
+        return None
+
+    async def enqueue_pagination_job(self, *, job: FetchJob) -> None:
+        symbol = _symbol_key(job)
+        while True:
+            async with self._lock:
+                wait_event = self._try_enqueue_pagination_job(symbol=symbol, job=job)
+                if wait_event is None:
+                    return
+                wait_task = asyncio.create_task(wait_event.wait())
+            try:
+                await wait_task
+            except asyncio.CancelledError:
+                wait_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await wait_task
+                raise
+
+    async def mark_pagination_job_done(self) -> None:
+        async with self._lock:
+            if self._state.unfinished_jobs <= 0:
+                raise RuntimeError("pagination fairness accounting underflow")
+            self._state.unfinished_jobs -= 1
+            self._events.sync_from_state(fairness_state=self._state)
+
+    async def wait_for_pagination_drain(self) -> None:
+        self._events.sync_from_state(fairness_state=self._state)
+        await self._events.drained.wait()
+
+    async def wait_for_pagination_availability(self) -> None:
+        self._events.sync_from_state(fairness_state=self._state)
+        await self._events.available.wait()
+
+    async def wait_for_pagination_below_threshold(self) -> None:
+        self._events.sync_from_state(fairness_state=self._state)
+        await self._events.below_threshold.wait()
+
+    async def pop_next_job_respecting_fairness(self, *, priority_pagination: int) -> SchedulerResult:
+        """Select the next paginated job using Deficit Round Robin."""
+        async with self._lock:
+            self._events.sync_from_state(fairness_state=self._state)
+            while self._state.active:
+                symbol = self._state.active[0]
+                symbol_queue = self._state.queues.get(symbol)
+                if not symbol_queue:
+                    self._state.active.popleft()
+                    self._state.active_symbols.discard(symbol)
+                    self._state.queues.pop(symbol, None)
+                    self._state.deficit.pop(symbol, None)
+                    self._events._cleanup_symbol_events(symbol)
+                    continue
+                current_deficit = self._state.deficit.get(symbol, 0.0)
+                if current_deficit < 1.0:
+                    self._state.deficit[symbol] = current_deficit + self._state.quantum
+                if self._state.deficit[symbol] < 1.0:
+                    self._state.active.rotate(-1)
+                    continue
+                job = symbol_queue.popleft()
+                self._state.total_backlog -= 1
+                self._state.deficit[symbol] -= 1.0
+                if symbol_queue:
+                    self._events.sync_symbol(
+                        fairness_state=self._state,
+                        symbol=symbol,
+                        depth=len(symbol_queue),
+                    )
+                    if self._state.deficit[symbol] < 1.0:
+                        self._state.active.rotate(-1)
+                else:
+                    self._state.active.popleft()
+                    self._state.active_symbols.discard(symbol)
+                    self._state.queues.pop(symbol, None)
+                    self._state.deficit.pop(symbol, None)
+                    self._events._cleanup_symbol_events(symbol)
+                self._events.sync_from_state(fairness_state=self._state)
+                return SchedulerResult(priority=priority_pagination, job=job, demoted=[], already_done=False)
+            self._events.sync_from_state(fairness_state=self._state)
+            return SchedulerResult(priority=priority_pagination, job=None, demoted=[], already_done=False)
+
+
+_WAITER_CACHE: dict[tuple[int, int], FairnessWaiter] = {}
+
+
+def _get_waiter(*, fair_lock: asyncio.Lock, fairness_state: FairnessState) -> FairnessWaiter:
+    key = (id(fair_lock), id(fairness_state))
+    waiter = _WAITER_CACHE.get(key)
+    if waiter is None:
+        waiter = FairnessWaiter(
+            fair_lock=fair_lock,
+            fairness_state=fairness_state,
+            fairness_events=FairnessEvents(),
+        )
+        _WAITER_CACHE[key] = waiter
+    return waiter
 
 
 def _queued_backlog(*, fairness_state: FairnessState) -> int:
-    return sum(len(queue) for queue in fairness_state.queues.values())
-
-
-def _sync_below_threshold_event(*, fairness_state: FairnessState) -> None:
-    if (
-        fairness_state.backpressure_threshold is None
-        or _queued_backlog(fairness_state=fairness_state) < fairness_state.backpressure_threshold
-    ):
-        fairness_state.below_threshold.set()
-    else:
-        fairness_state.below_threshold.clear()
-
-
-def _sync_symbol_capacity_event(*, fairness_state: FairnessState, symbol: str, depth: int) -> None:
-    if fairness_state.max_pending_per_symbol is None:
-        return
-    event = _ensure_symbol_capacity_event(fairness_state=fairness_state, symbol=symbol)
-    if depth >= fairness_state.max_pending_per_symbol:
-        event.clear()
-    else:
-        event.set()
-
-
-def _try_enqueue_pagination_job(*, fairness_state: FairnessState, symbol: str, job: FetchJob) -> list[asyncio.Event]:
-    q = fairness_state.queues.get(symbol)
-    current_depth = len(q) if q is not None else 0
-    waits: list[asyncio.Event] = []
-    if (
-        fairness_state.backpressure_threshold is not None
-        and _queued_backlog(fairness_state=fairness_state) >= fairness_state.backpressure_threshold
-    ):
-        waits.append(fairness_state.below_threshold)
-    if fairness_state.max_pending_per_symbol is not None and current_depth >= fairness_state.max_pending_per_symbol:
-        waits.append(_ensure_symbol_capacity_event(fairness_state=fairness_state, symbol=symbol))
-    if waits:
-        return waits
-    if q is None:
-        q = deque()
-        fairness_state.queues[symbol] = q
-    q.append(job)
-    if symbol not in fairness_state.active_symbols:
-        fairness_state.active.append(symbol)
-        fairness_state.active_symbols.add(symbol)
-    fairness_state.unfinished_jobs += 1
-    fairness_state.drained.clear()
-    fairness_state.available.set()
-    _sync_below_threshold_event(fairness_state=fairness_state)
-    _sync_symbol_capacity_event(fairness_state=fairness_state, symbol=symbol, depth=len(q))
-    return []
+    return fairness_state.total_backlog
 
 
 async def enqueue_pagination_job(
@@ -124,29 +277,7 @@ async def enqueue_pagination_job(
     fairness_state: FairnessState,
     job: FetchJob,
 ) -> None:
-    symbol = _symbol_key(job)
-    while True:
-        async with fair_lock:
-            wait_events = _try_enqueue_pagination_job(fairness_state=fairness_state, symbol=symbol, job=job)
-            if not wait_events:
-                return
-            waits = [asyncio.create_task(event.wait()) for event in wait_events]
-        try:
-            done, pending = await asyncio.wait(set(waits), return_when=asyncio.FIRST_COMPLETED)
-        except asyncio.CancelledError:
-            for task in waits:
-                task.cancel()
-            for task in waits:
-                with contextlib.suppress(asyncio.CancelledError):
-                    await task
-            raise
-        for task in pending:
-            task.cancel()
-        for task in pending:
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-        for task in done:
-            task.result()
+    await _get_waiter(fair_lock=fair_lock, fairness_state=fairness_state).enqueue_pagination_job(job=job)
 
 
 async def mark_pagination_job_done(
@@ -154,25 +285,43 @@ async def mark_pagination_job_done(
     fair_lock: asyncio.Lock,
     fairness_state: FairnessState,
 ) -> None:
-    async with fair_lock:
-        if fairness_state.unfinished_jobs <= 0:
-            raise RuntimeError("pagination fairness accounting underflow")
-        fairness_state.unfinished_jobs -= 1
-        if fairness_state.unfinished_jobs == 0:
-            fairness_state.drained.set()
-        _sync_below_threshold_event(fairness_state=fairness_state)
+    await _get_waiter(fair_lock=fair_lock, fairness_state=fairness_state).mark_pagination_job_done()
 
 
 async def wait_for_pagination_drain(*, fairness_state: FairnessState) -> None:
-    await fairness_state.drained.wait()
+    for waiter in _WAITER_CACHE.values():
+        if waiter._state is fairness_state:
+            await waiter.wait_for_pagination_drain()
+            return
+    await FairnessWaiter(
+        fair_lock=asyncio.Lock(),
+        fairness_state=fairness_state,
+        fairness_events=FairnessEvents(),
+    ).wait_for_pagination_drain()
 
 
 async def wait_for_pagination_availability(*, fairness_state: FairnessState) -> None:
-    await fairness_state.available.wait()
+    for waiter in _WAITER_CACHE.values():
+        if waiter._state is fairness_state:
+            await waiter.wait_for_pagination_availability()
+            return
+    await FairnessWaiter(
+        fair_lock=asyncio.Lock(),
+        fairness_state=fairness_state,
+        fairness_events=FairnessEvents(),
+    ).wait_for_pagination_availability()
 
 
 async def wait_for_pagination_below_threshold(*, fairness_state: FairnessState) -> None:
-    await fairness_state.below_threshold.wait()
+    for waiter in _WAITER_CACHE.values():
+        if waiter._state is fairness_state:
+            await waiter.wait_for_pagination_below_threshold()
+            return
+    await FairnessWaiter(
+        fair_lock=asyncio.Lock(),
+        fairness_state=fairness_state,
+        fairness_events=FairnessEvents(),
+    ).wait_for_pagination_below_threshold()
 
 
 async def pop_next_job_respecting_fairness(
@@ -181,39 +330,7 @@ async def pop_next_job_respecting_fairness(
     priority_pagination: int,
     fairness_state: FairnessState,
 ) -> SchedulerResult:
-    """Select the next paginated job using Deficit Round Robin."""
-    async with fair_lock:
-        while fairness_state.active:
-            symbol = fairness_state.active[0]
-            symbol_queue = fairness_state.queues.get(symbol)
-            if not symbol_queue:
-                fairness_state.active.popleft()
-                fairness_state.active_symbols.discard(symbol)
-                fairness_state.queues.pop(symbol, None)
-                fairness_state.deficit.pop(symbol, None)
-                fairness_state.symbol_capacity.pop(symbol, None)
-                continue
-            current_deficit = fairness_state.deficit.get(symbol, 0.0)
-            if current_deficit < 1.0:
-                fairness_state.deficit[symbol] = current_deficit + fairness_state.quantum
-            if fairness_state.deficit[symbol] < 1.0:
-                fairness_state.active.rotate(-1)
-                continue
-            job = symbol_queue.popleft()
-            fairness_state.deficit[symbol] -= 1.0
-            _sync_symbol_capacity_event(fairness_state=fairness_state, symbol=symbol, depth=len(symbol_queue))
-            if symbol_queue:
-                if fairness_state.deficit[symbol] < 1.0:
-                    fairness_state.active.rotate(-1)
-            else:
-                fairness_state.active.popleft()
-                fairness_state.active_symbols.discard(symbol)
-                fairness_state.queues.pop(symbol, None)
-                fairness_state.deficit.pop(symbol, None)
-                fairness_state.symbol_capacity.pop(symbol, None)
-            _sync_below_threshold_event(fairness_state=fairness_state)
-            if not fairness_state.active:
-                fairness_state.available.clear()
-            return SchedulerResult(priority=priority_pagination, job=job, demoted=[], already_done=False)
-        fairness_state.available.clear()
-        return SchedulerResult(priority=priority_pagination, job=None, demoted=[], already_done=False)
+    return await _get_waiter(
+        fair_lock=fair_lock,
+        fairness_state=fairness_state,
+    ).pop_next_job_respecting_fairness(priority_pagination=priority_pagination)

--- a/packages/vertex-forager/src/vertex_forager/core/scheduler.py
+++ b/packages/vertex-forager/src/vertex_forager/core/scheduler.py
@@ -6,6 +6,7 @@ import contextlib
 from dataclasses import dataclass, field
 import math
 from typing import TYPE_CHECKING
+from weakref import WeakValueDictionary
 
 if TYPE_CHECKING:
     from vertex_forager.core.config import FetchJob
@@ -251,7 +252,7 @@ class FairnessWaiter:
             return SchedulerResult(priority=priority_pagination, job=None, demoted=[], already_done=False)
 
 
-_WAITER_CACHE: dict[tuple[int, int], FairnessWaiter] = {}
+_WAITER_CACHE: WeakValueDictionary[tuple[int, int], FairnessWaiter] = WeakValueDictionary()
 
 
 def _get_waiter(*, fair_lock: asyncio.Lock, fairness_state: FairnessState) -> FairnessWaiter:
@@ -288,39 +289,36 @@ async def mark_pagination_job_done(
     await _get_waiter(fair_lock=fair_lock, fairness_state=fairness_state).mark_pagination_job_done()
 
 
-async def wait_for_pagination_drain(*, fairness_state: FairnessState) -> None:
-    for waiter in _WAITER_CACHE.values():
-        if waiter._state is fairness_state:
-            await waiter.wait_for_pagination_drain()
-            return
-    await FairnessWaiter(
-        fair_lock=asyncio.Lock(),
+async def wait_for_pagination_drain(
+    *,
+    fair_lock: asyncio.Lock,
+    fairness_state: FairnessState,
+) -> None:
+    await _get_waiter(
+        fair_lock=fair_lock,
         fairness_state=fairness_state,
-        fairness_events=FairnessEvents(),
     ).wait_for_pagination_drain()
 
 
-async def wait_for_pagination_availability(*, fairness_state: FairnessState) -> None:
-    for waiter in _WAITER_CACHE.values():
-        if waiter._state is fairness_state:
-            await waiter.wait_for_pagination_availability()
-            return
-    await FairnessWaiter(
-        fair_lock=asyncio.Lock(),
+async def wait_for_pagination_availability(
+    *,
+    fair_lock: asyncio.Lock,
+    fairness_state: FairnessState,
+) -> None:
+    await _get_waiter(
+        fair_lock=fair_lock,
         fairness_state=fairness_state,
-        fairness_events=FairnessEvents(),
     ).wait_for_pagination_availability()
 
 
-async def wait_for_pagination_below_threshold(*, fairness_state: FairnessState) -> None:
-    for waiter in _WAITER_CACHE.values():
-        if waiter._state is fairness_state:
-            await waiter.wait_for_pagination_below_threshold()
-            return
-    await FairnessWaiter(
-        fair_lock=asyncio.Lock(),
+async def wait_for_pagination_below_threshold(
+    *,
+    fair_lock: asyncio.Lock,
+    fairness_state: FairnessState,
+) -> None:
+    await _get_waiter(
+        fair_lock=fair_lock,
         fairness_state=fairness_state,
-        fairness_events=FairnessEvents(),
     ).wait_for_pagination_below_threshold()
 
 

--- a/packages/vertex-forager/src/vertex_forager/core/workerio.py
+++ b/packages/vertex-forager/src/vertex_forager/core/workerio.py
@@ -15,6 +15,14 @@ if TYPE_CHECKING:
     from vertex_forager.core.config import FetchJob, FramePacket, ParseResult, RunResult
 
 
+def _normalize_all(
+    *,
+    packets: list[FramePacket],
+    normalize_packet: Callable[..., FramePacket],
+) -> list[FramePacket]:
+    return [normalize_packet(packet=packet) for packet in packets]
+
+
 async def fetch_payload(
     *,
     worker_id: int,
@@ -72,6 +80,7 @@ async def parse_payload(
         )
     parse_latency = time.monotonic() - t1
     observe("parse_duration_s", parse_latency)
+    observe(f"parse_duration_s.{job.provider}.{job.dataset}", parse_latency)
     logger.debug(
         "[Worker-%s] Parsed %s in %.3fs. Packets: %s, Next Jobs: %s",
         worker_id,
@@ -105,12 +114,16 @@ async def emit_packets_and_next_jobs(
     enqueue_pagination_job: Callable[[FetchJob], Awaitable[None]],
     logger: Any,
 ) -> None:
-    for packet in parse_result.packets:
+    normalized_packets: list[FramePacket]
+    if parse_result.packets:
         loop = asyncio.get_running_loop()
-        normalized_packet = await loop.run_in_executor(
+        normalized_packets = await loop.run_in_executor(
             parse_executor,
-            partial(normalize_packet, packet=packet),
+            partial(_normalize_all, packets=parse_result.packets, normalize_packet=normalize_packet),
         )
+    else:
+        normalized_packets = []
+    for normalized_packet in normalized_packets:
         await pkt_q.put(normalized_packet)
         inc("packets_emitted", 1)
     if parse_result.next_jobs:

--- a/packages/vertex-forager/src/vertex_forager/core/writerflush.py
+++ b/packages/vertex-forager/src/vertex_forager/core/writerflush.py
@@ -545,6 +545,7 @@ async def flush_chunked_table(
     packets: list[FramePacket],
     schema: TableSchema | None,
     chunk_size: int,
+    total_rows: int,
     buffers: dict[str, list[FramePacket]],
     buffer_rows: dict[str, int],
     result: RunResult,
@@ -556,13 +557,12 @@ async def flush_chunked_table(
     logger: LoggerLike,
 ) -> None:
     first = packets[0]
-    total_rows_est = sum(len(p.frame) for p in packets)
-    if total_rows_est > 0:
-        est_chunks = (total_rows_est + chunk_size - 1) // chunk_size
+    if total_rows > 0:
+        est_chunks = (total_rows + chunk_size - 1) // chunk_size
         logger.debug(
             "WRITER: Chunking flush for %s rows~=%s chunk_size=%s chunks~=%s",
             table,
-            total_rows_est,
+            total_rows,
             chunk_size,
             est_chunks,
         )
@@ -570,7 +570,7 @@ async def flush_chunked_table(
             provider=first.provider,
             dataset=first.table,
             symbol=None,
-            stage=f"write_chunking_rows_{total_rows_est}_size_{chunk_size}_chunks_{est_chunks}",
+            stage=f"write_chunking_rows_{total_rows}_size_{chunk_size}_chunks_{est_chunks}",
         )
     for chunk in planner.plan(packets=packets, chunk_size=chunk_size):
         try:
@@ -615,6 +615,7 @@ async def flush_writer_table(
         packets=packets,
         schema=schema,
         chunk_size=WRITER_CHUNK_ROWS,
+        total_rows=buffer_rows.get(table, 0),
         buffers=buffers,
         buffer_rows=buffer_rows,
         result=result,

--- a/packages/vertex-forager/tests/unit/test_core_scheduler.py
+++ b/packages/vertex-forager/tests/unit/test_core_scheduler.py
@@ -13,6 +13,7 @@ from vertex_forager.core.scheduler import (
     enqueue_pagination_job,
     mark_pagination_job_done,
     pop_next_job_respecting_fairness,
+    wait_for_pagination_drain,
 )
 
 
@@ -257,3 +258,17 @@ async def test_total_backlog_tracks_enqueued_and_popped_jobs() -> None:
     result_b = await waiter.pop_next_job_respecting_fairness(priority_pagination=1)
     assert result_b.job is not None
     assert state.total_backlog == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_pagination_drain_uses_canonical_waiter() -> None:
+    state = FairnessState(quantum=3)
+    lock = asyncio.Lock()
+
+    await enqueue_pagination_job(fair_lock=lock, fairness_state=state, job=_job("AAPL", 1))
+    waiter = asyncio.create_task(wait_for_pagination_drain(fair_lock=lock, fairness_state=state))
+    await asyncio.sleep(0)
+    assert waiter.done() is False
+
+    await mark_pagination_job_done(fair_lock=lock, fairness_state=state)
+    await asyncio.wait_for(waiter, timeout=0.5)

--- a/packages/vertex-forager/tests/unit/test_core_scheduler.py
+++ b/packages/vertex-forager/tests/unit/test_core_scheduler.py
@@ -7,7 +7,9 @@ import pytest
 
 from vertex_forager.core.config import FetchJob, RequestSpec
 from vertex_forager.core.scheduler import (
+    FairnessEvents,
     FairnessState,
+    FairnessWaiter,
     enqueue_pagination_job,
     mark_pagination_job_done,
     pop_next_job_respecting_fairness,
@@ -21,6 +23,10 @@ def _job(symbol: str, page: int) -> FetchJob:
         symbol=symbol,
         spec=RequestSpec(url=f"https://example.test/{symbol}/{page}", params={"ticker": symbol, "page": page}),
     )
+
+
+def _waiter(lock: asyncio.Lock, state: FairnessState) -> FairnessWaiter:
+    return FairnessWaiter(fair_lock=lock, fairness_state=state, fairness_events=FairnessEvents())
 
 
 @pytest.mark.asyncio
@@ -122,9 +128,10 @@ async def test_new_symbol_enters_active_list_mid_run() -> None:
 async def test_drr_drained_event_tracks_unfinished_jobs() -> None:
     state = FairnessState(quantum=3)
     lock = asyncio.Lock()
-    await enqueue_pagination_job(fair_lock=lock, fairness_state=state, job=_job("TSLA", 1))
+    waiter = _waiter(lock, state)
+    await waiter.enqueue_pagination_job(job=_job("TSLA", 1))
 
-    assert state.drained.is_set() is False
+    assert waiter._events.drained.is_set() is False
 
     result = await pop_next_job_respecting_fairness(
         fair_lock=lock,
@@ -135,9 +142,9 @@ async def test_drr_drained_event_tracks_unfinished_jobs() -> None:
     assert result.job is not None
     assert result.job.symbol == "TSLA"
 
-    await mark_pagination_job_done(fair_lock=lock, fairness_state=state)
+    await waiter.mark_pagination_job_done()
 
-    assert state.drained.is_set() is True
+    assert waiter._events.drained.is_set() is True
 
 
 @pytest.mark.asyncio
@@ -208,16 +215,13 @@ async def test_backpressure_ignores_currently_running_job() -> None:
 async def test_symbol_capacity_cache_is_removed_when_queue_drains() -> None:
     state = FairnessState(quantum=3, max_pending_per_symbol=1)
     lock = asyncio.Lock()
-    await enqueue_pagination_job(fair_lock=lock, fairness_state=state, job=_job("AAPL", 1))
+    waiter = _waiter(lock, state)
+    await waiter.enqueue_pagination_job(job=_job("AAPL", 1))
 
-    result = await pop_next_job_respecting_fairness(
-        fair_lock=lock,
-        priority_pagination=1,
-        fairness_state=state,
-    )
+    result = await waiter.pop_next_job_respecting_fairness(priority_pagination=1)
 
     assert result.job is not None
-    assert "AAPL" not in state.symbol_capacity
+    assert "AAPL" not in waiter._events.symbol_capacity
 
 
 @pytest.mark.asyncio
@@ -226,14 +230,30 @@ async def test_symbol_capacity_cache_is_removed_for_stale_empty_queue() -> None:
     state.active.append("AAPL")
     state.active_symbols.add("AAPL")
     state.queues["AAPL"] = deque()
-    state.symbol_capacity["AAPL"] = asyncio.Event()
     lock = asyncio.Lock()
+    waiter = _waiter(lock, state)
+    waiter._events.symbol_capacity["AAPL"] = asyncio.Event()
 
-    result = await pop_next_job_respecting_fairness(
-        fair_lock=lock,
-        priority_pagination=1,
-        fairness_state=state,
-    )
+    result = await waiter.pop_next_job_respecting_fairness(priority_pagination=1)
 
     assert result.job is None
-    assert "AAPL" not in state.symbol_capacity
+    assert "AAPL" not in waiter._events.symbol_capacity
+
+
+@pytest.mark.asyncio
+async def test_total_backlog_tracks_enqueued_and_popped_jobs() -> None:
+    state = FairnessState(quantum=3)
+    lock = asyncio.Lock()
+    waiter = _waiter(lock, state)
+
+    await waiter.enqueue_pagination_job(job=_job("AAPL", 1))
+    await waiter.enqueue_pagination_job(job=_job("MSFT", 1))
+    assert state.total_backlog == 2
+
+    result_a = await waiter.pop_next_job_respecting_fairness(priority_pagination=1)
+    assert result_a.job is not None
+    assert state.total_backlog == 1
+
+    result_b = await waiter.pop_next_job_respecting_fairness(priority_pagination=1)
+    assert result_b.job is not None
+    assert state.total_backlog == 0

--- a/packages/vertex-forager/tests/unit/test_core_workerio.py
+++ b/packages/vertex-forager/tests/unit/test_core_workerio.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from datetime import datetime
 import itertools
 
@@ -8,7 +9,7 @@ import polars as pl
 import pytest
 
 from vertex_forager.core.config import FetchJob, FramePacket, ParseResult, RequestSpec, RunResult
-from vertex_forager.core.workerio import emit_packets_and_next_jobs, record_worker_error
+from vertex_forager.core.workerio import emit_packets_and_next_jobs, parse_payload, record_worker_error
 
 
 def _job(symbol: str) -> FetchJob:
@@ -59,6 +60,92 @@ async def test_emit_packets_and_next_jobs_emits_and_enqueues() -> None:
     assert req_q.empty()
     assert len(enqueued) == 1
     assert enqueued[0].symbol == "MSFT"
+
+
+@pytest.mark.asyncio
+async def test_emit_packets_and_next_jobs_batches_normalize_executor_calls(monkeypatch: pytest.MonkeyPatch) -> None:
+    packets = [
+        FramePacket(
+            provider="sharadar",
+            table="sharadar_price",
+            frame=pl.DataFrame({"ticker": ["AAPL"]}),
+            observed_at=datetime.now(),
+        ),
+        FramePacket(
+            provider="sharadar",
+            table="sharadar_price",
+            frame=pl.DataFrame({"ticker": ["MSFT"]}),
+            observed_at=datetime.now(),
+        ),
+    ]
+    parse_result = ParseResult(packets=packets, next_jobs=[])
+    pkt_q: asyncio.Queue[FramePacket | None] = asyncio.Queue()
+    calls = {"executor": 0}
+
+    async def _capture_enqueue(job: FetchJob) -> None:
+        raise AssertionError(f"unexpected pagination enqueue: {job}")
+
+    class _Loop:
+        async def run_in_executor(self, executor: object, func: object) -> object:
+            del executor
+            calls["executor"] += 1
+            return func()
+
+    monkeypatch.setattr("vertex_forager.core.workerio.asyncio.get_running_loop", lambda: _Loop())
+
+    await emit_packets_and_next_jobs(
+        parse_result=parse_result,
+        req_q=asyncio.PriorityQueue(),
+        pkt_q=pkt_q,
+        order_counter=itertools.count(),
+        worker_id=1,
+        job=_job("AAPL"),
+        parse_executor=object(),
+        normalize_packet=lambda packet: packet,
+        inc=lambda _name, _amount: None,
+        priority_pagination=1,
+        enqueue_pagination_job=_capture_enqueue,
+        logger=type("L", (), {"debug": lambda *args, **kwargs: None})(),
+    )
+
+    assert calls["executor"] == 1
+    assert pkt_q.qsize() == 2
+
+
+@pytest.mark.asyncio
+async def test_parse_payload_emits_tagged_parse_metric() -> None:
+    observed: list[tuple[str, float]] = []
+
+    class _Loop:
+        async def run_in_executor(self, executor: object, func: object) -> object:
+            del executor
+            return func()
+
+    result = ParseResult(packets=[], next_jobs=[])
+
+    @contextmanager
+    def _span(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        yield
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr("vertex_forager.core.workerio.asyncio.get_running_loop", lambda: _Loop())
+        parsed = await parse_payload(
+            job=_job("AAPL"),
+            payload=b"ok",
+            worker_id=1,
+            parse_executor=object(),
+            router_parse=lambda **kwargs: result,
+            span=_span,
+            observe=lambda name, value: observed.append((name, value)),
+            log_structured=lambda **kwargs: None,
+            logger=type("L", (), {"debug": lambda *args, **kwargs: None})(),
+        )
+
+    assert parsed is result
+    names = [name for name, _ in observed]
+    assert "parse_duration_s" in names
+    assert "parse_duration_s.sharadar.price" in names
 
 
 @pytest.mark.asyncio

--- a/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
+++ b/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
@@ -879,7 +879,8 @@ async def test_fairness_prefers_req_get_when_both_waits_complete(monkeypatch: py
 
     req_q: asyncio.PriorityQueue[tuple[int, int, FetchJob | None]] = asyncio.PriorityQueue()
 
-    async def _immediate_pagination_wait(*, fairness_state: FairnessState) -> None:
+    async def _immediate_pagination_wait(*, fair_lock: asyncio.Lock, fairness_state: FairnessState) -> None:
+        del fair_lock, fairness_state
         return None
 
     async def _immediate_req_get(

--- a/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
+++ b/packages/vertex-forager/tests/unit/test_pipeline_coverage.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 from contextlib import asynccontextmanager
 import itertools
 import logging
@@ -644,6 +645,18 @@ async def test_progress_snapshot_uses_retained_sample_window_for_throughput(
 
     assert snapshots
     assert snapshots[-1].throughput_sym_per_s == pytest.approx(0.8)
+
+
+def test_build_summary_emits_tagged_parse_duration_percentiles() -> None:
+    router = _PaginatingRouter(pages=0)
+    engine, _ = _make_engine(router)
+    engine._hists["parse_duration_s.sharadar.price"] = deque([0.1, 0.2, 0.3])
+
+    summary = engine._compute_summary()
+
+    assert summary["parse_duration_s.sharadar.price_p50"] == 0.2
+    assert summary["parse_duration_s.sharadar.price_p95"] == 0.3
+    assert summary["parse_duration_s.sharadar.price_p99"] == 0.3
 
 
 @pytest.mark.asyncio

--- a/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
+++ b/packages/vertex-forager/tests/verification/verify_core_perf_budget.py
@@ -117,6 +117,7 @@ async def test_retry_and_writer_chunk_perf_budget() -> None:
         packets=packets,
         schema=object(),
         chunk_size=120,
+        total_rows=sum(len(p.frame) for p in packets),
         buffers={"t": packets.copy()},
         buffer_rows={"t": sum(len(p.frame) for p in packets)},
         result=RunResult(provider="test"),


### PR DESCRIPTION
## Summary

- Reduce hot-path overhead in pagination scheduling, parsing, and writer chunk flushing.
- Separate fairness wait/event coordination from raw scheduler state and remove avoidable repeated work in parse normalization and chunk flush accounting.

## Linked Issue

- Closes #473

## Changes

- Refactor `packages/vertex-forager/src/vertex_forager/core/scheduler.py`
- Add `total_backlog` to `FairnessState`
- Add `FairnessEvents` to manage `drained`, `available`, threshold, and per-symbol capacity/enqueue events separately from scheduler state
- Add `FairnessWaiter` to own enqueue waiting and DRR dequeue orchestration while keeping the public scheduler helpers as thin wrappers
- Update `packages/vertex-forager/src/vertex_forager/core/workerio.py`
- Batch packet normalization into a single executor hop per parse result instead of one executor hop per packet
- Emit tagged parse metrics via `parse_duration_s.<provider>.<dataset>`
- Update `packages/vertex-forager/src/vertex_forager/core/pipeline.py`
- Include tagged parse-duration percentile summaries in `_compute_summary()`
- Update `packages/vertex-forager/src/vertex_forager/core/writerflush.py`
- Pass precomputed `total_rows` into `flush_chunked_table()` so chunk logging does not rescan packet frames
- Update tests in `packages/vertex-forager/tests/unit/test_core_scheduler.py`, `packages/vertex-forager/tests/unit/test_core_workerio.py`, and `packages/vertex-forager/tests/unit/test_pipeline_coverage.py`
- Update `packages/vertex-forager/tests/verification/verify_core_perf_budget.py` to the new writer flush signature

## Verification

- Ran `uv run pytest packages/vertex-forager/tests/unit/test_core_scheduler.py packages/vertex-forager/tests/unit/test_core_workerio.py packages/vertex-forager/tests/unit/test_core_writerflush.py packages/vertex-forager/tests/unit/test_pipeline_coverage.py -q`
- Ran `uv run ruff check packages/vertex-forager/src packages/vertex-forager/tests`
- Ran `uv run mypy packages/vertex-forager/src --strict`
- Ran `uv run python scripts/check_cycles.py`
- Ran `uv run pytest packages/ --cov-fail-under=80 -q`
- Verified results: `74 passed` for targeted tests, `558 passed` for full test suite, `ruff` pass, `mypy` pass, import cycle check pass

## Checklist

- [x] ruff/mypy/pytest pass locally
- [ ] Docs updated (if user-visible)
- [ ] Changelog entry (if user-visible)
- [x] No secrets committed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 구문 분석 성능 메트릭에 대상별 백분위수(p50, p95, p99) 태그 추가

* **개선사항**
  * 다중 패킷 정규화 시 실행기 호출을 배치화해 처리 효율 개선
  * 공정성 기반 스케줄링의 대기·드레인/가용성 동기화와 총 대기량 집계 로직 개선
  * 기록 플러시에서 총 행 수 명시로 청크 계산·로깅 개선

* **테스트**
  * 관련 단위 및 검증 테스트 추가/갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->